### PR TITLE
Blog scheduled publishing: publishAt gating, hourly ISR, cadence calendar

### DIFF
--- a/BLOG_STRATEGY.md
+++ b/BLOG_STRATEGY.md
@@ -67,15 +67,41 @@ recurring P1-style distribution material. Real numbers only, $0 included.
 
 ## 4. Cadence (realistic)
 
-**One post per week**, rotating pillars: P3 → P1/P2 → P3 → P4 (monthly
-metrics post anchors week 4). That's ~2 evergreen SEO posts + ~2 brand
-posts per month. Agent-written drafts make volume cheap; the constraint is
-the truth-pass and human review, so one/week is the honest ceiling. If a
-week slips, slip it — never backfill with thin content; the brand cannot
-afford a single fabricated number.
+**One post per week, going live Tuesdays at 13:00 UTC** (guaranteed live by
+14:00 UTC = 10am ET / 7am PT with the hourly ISR revalidation). Rationale:
+Tuesday mid-week is peak developer attention; a post that is live by
+US-morning lets the human owner submit to Hacker News in HN's
+highest-traffic window (US morning) the same day, with the page already
+warm; and one fixed slot makes the schedule auditable — a missed Tuesday is
+visible, which suits the radical-honesty brand.
+
+Pillar rotation: P3 → P1/P2 → P3 → P4 (monthly metrics post anchors the
+month boundary). That's ~2 evergreen SEO posts + ~2 brand posts per month.
+Agent-written drafts make volume cheap; the constraint is the truth-pass
+and human review, so one/week is the honest ceiling. If a week slips, slip
+it — never backfill with thin content; the brand cannot afford a single
+fabricated number.
 
 Refreshes count as slots: updating an existing post (see §8) may replace a
 new post in any given week.
+
+### Forward publishing workflow (scheduled, never all-at-once)
+
+`lib/blog.ts` gates publication: every post has a `publishAt` (ISO UTC),
+and `getPublishedPosts()` filters the index, sitemap, prev/next links,
+related posts, and daily-email accomplishments. Post pages return 404
+before their `publishAt` and revalidate hourly, so a scheduled post goes
+live automatically within the hour — no publish-day deploy.
+
+The loop per post:
+1. Course-content agent writes the post; it merges whenever ready with a
+   future `publishAt` from the calendar below (registry entry + page).
+2. Truth-pass against COURSE_FACTS.md happens at PR review, not at
+   publish time — what merges is already publishable.
+3. It goes live automatically in the Tuesday slot. Nothing to press.
+4. Same week, I hand the human owner the distribution draft pack (§6) keyed
+   to that post; the owner posts after confirming the URL is live.
+5. Two weeks later the post gets its scorecard (§7).
 
 ## 5. How posts feed the email gate
 
@@ -152,21 +178,27 @@ business from $0 to $80k/month" — banned-adjacent framing ("$80,000/month
 as imminent"); replace with honest positioning. SEO-surface fix, my lane,
 flagged for a follow-up dispatch.
 
-## 9. First 8 weeks (calendar)
+## 9. First 8 weeks (calendar, keyed to publishAt)
 
-| Wk | Pillar | Post | Distribution |
-|---|---|---|---|
-| 1 | P2 | "My AI agents ran my business unattended for 4 months. Here's the damage." — the July audit as flagship relaunch post | HN + X drafts |
-| 2 | — | Retrofit sprint: CTA migration on all 7 posts + index-metadata fix + Agentix/monetization addenda | — |
-| 3 | P3 | "CLAUDE.md is my operating manual: how a repo file runs a business" (uses our real CLAUDE.md, as COURSE_FACTS endorses) | X draft |
-| 4 | P4 | Metrics report #1: July numbers — 351 signups, $0 revenue, first gate-conversion data | HN + email draft |
-| 5 | P3 | "Claude Code headless (`claude -p`): building an unattended worker" → feeds modules 1–2 | Reddit draft |
-| 6 | P2 | "Every unsubscribe link I ever sent was broken" — email-infra post-mortem | HN draft |
-| 7 | P3 | "One orchestrator, N worktrees: how my worker fleet actually runs (Orca)" | X draft |
-| 8 | P4/P1 | Metrics report #2 + what the first month of publishing changed | email draft |
+All slots are Tuesdays; `publishAt` is the exact registry value. The CTA
+retrofit sprint originally penciled as week 2 shipped early (2026-07-12),
+so every week is a publishing week.
 
-Weeks 1, 2, and 4 are the highest-leverage items if only three things
-happen.
+| Wk | publishAt (UTC) | Pillar | Post | Distribution |
+|---|---|---|---|---|
+| 1 | 2026-07-14T13:00:00Z | P2 | "My AI agents ran my business unattended for 4 months. Here's the damage." — the July audit as flagship relaunch post | HN + X drafts |
+| 2 | 2026-07-21T13:00:00Z | P3 | "CLAUDE.md is my operating manual: how a repo file runs a business" (uses our real CLAUDE.md, as COURSE_FACTS endorses) | X draft |
+| 3 | 2026-07-28T13:00:00Z | P3 | "Claude Code headless (`claude -p`): building an unattended worker" → feeds modules 1–2 | Reddit draft |
+| 4 | 2026-08-04T13:00:00Z | P4 | Metrics report #1: July numbers — signups, $0 revenue, first gate-conversion data | HN + email draft |
+| 5 | 2026-08-11T13:00:00Z | P2 | "Every unsubscribe link I ever sent was broken" — email-infra post-mortem | HN draft |
+| 6 | 2026-08-18T13:00:00Z | P3 | "One orchestrator, N worktrees: how my worker fleet actually runs (Orca)" | X draft |
+| 7 | 2026-08-25T13:00:00Z | P1 | "The course is free; it costs one confirmed email" — the gate decision, with its first real conversion numbers | X draft |
+| 8 | 2026-09-01T13:00:00Z | P4 | Metrics report #2: August numbers + what the first publishing month changed | email draft |
+
+Weeks 1 and 4 are the highest-leverage items if only two things happen.
+Note for module counts and any metric cited in these posts: COURSE_FACTS.md
+is the source of truth at write time, and the truth-pass happens in PR
+review before merge.
 
 ## 10. Open items / escalations for the human owner
 

--- a/app/blog/5-ai-agents-you-can-build/page.tsx
+++ b/app/blog/5-ai-agents-you-can-build/page.tsx
@@ -1,6 +1,11 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "5 AI Agents You Can Build This Weekend",
@@ -53,6 +58,8 @@ const articleJsonLd = {
 };
 
 export default function FiveAgentsBlogPost() {
+  if (!isSlugPublished("5-ai-agents-you-can-build")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/blog/first-week-as-ai-ceo/page.tsx
+++ b/app/blog/first-week-as-ai-ceo/page.tsx
@@ -1,7 +1,12 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import { BlogBreadcrumb, BlogNavigation } from "@/components/BlogNavigation";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "First Week as an AI CEO: What I Learned Running a Real Business",
@@ -46,6 +51,8 @@ const articleJsonLd = {
 };
 
 export default function FirstWeekBlogPost() {
+  if (!isSlugPublished("first-week-as-ai-ceo")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/blog/how-i-built-an-ai-agent-business/page.tsx
+++ b/app/blog/how-i-built-an-ai-agent-business/page.tsx
@@ -1,6 +1,11 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "How I Built an AI Agent Business from Scratch",
@@ -53,6 +58,8 @@ const articleJsonLd = {
 };
 
 export default function HowIBuiltBlogPost() {
+  if (!isSlugPublished("how-i-built-an-ai-agent-business")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/blog/how-i-was-made/page.tsx
+++ b/app/blog/how-i-was-made/page.tsx
@@ -1,7 +1,12 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import { BlogBreadcrumb, BlogNavigation } from "@/components/BlogNavigation";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "How I Was Made: An AI CEO's First Post",
@@ -46,6 +51,8 @@ const articleJsonLd = {
 };
 
 export default function HowIWasMade() {
+  if (!isSlugPublished("how-i-was-made")) notFound();
+
   return (
     <div className="min-h-screen">
       <Header />

--- a/app/blog/how-to-build-your-first-ai-agent/page.tsx
+++ b/app/blog/how-to-build-your-first-ai-agent/page.tsx
@@ -1,6 +1,11 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "How to Build Your First AI Agent — Step-by-Step Guide",
@@ -53,6 +58,8 @@ const articleJsonLd = {
 };
 
 export default function HowToBuildYourFirstAIAgent() {
+  if (!isSlugPublished("how-to-build-your-first-ai-agent")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/blog/monetization-strategy-decision/page.tsx
+++ b/app/blog/monetization-strategy-decision/page.tsx
@@ -1,7 +1,12 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import { BlogBreadcrumb, BlogNavigation } from "@/components/BlogNavigation";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "How We Chose Our Monetization Strategy for an AI Agent Business",
@@ -46,6 +51,8 @@ const articleJsonLd = {
 };
 
 export default function MonetizationStrategyDecision() {
+  if (!isSlugPublished("monetization-strategy-decision")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,8 @@
 import { Header } from "@/components/Header";
-import { blogPosts } from "@/lib/blog";
+import { getPublishedPosts } from "@/lib/blog";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "AI CEO Blog — Building an AI Agent Business in Public",
@@ -18,7 +21,7 @@ export const metadata = {
 };
 
 export default function BlogPage() {
-  const [featured, ...rest] = blogPosts;
+  const [featured, ...rest] = getPublishedPosts();
 
   return (
     <main className="min-h-screen">

--- a/app/blog/why-we-switched-to-agentix/page.tsx
+++ b/app/blog/why-we-switched-to-agentix/page.tsx
@@ -1,7 +1,12 @@
+import { notFound } from "next/navigation";
+import { isSlugPublished } from "@/lib/blog";
 import { Header } from "@/components/Header";
 import { CourseUnlockCTA } from "@/components/CourseUnlockCTA";
 import { BlogBreadcrumb, BlogNavigation } from "@/components/BlogNavigation";
 import "../blog-post.css";
+
+// Revalidate hourly so a future publishAt goes live without a deploy.
+export const revalidate = 3600;
 
 export const metadata = {
   title: "Why We Switched to Agentix for AI Agent Worker Management",
@@ -46,6 +51,8 @@ const articleJsonLd = {
 };
 
 export default function WhyWeSwitchedToAgentix() {
+  if (!isSlugPublished("why-we-switched-to-agentix")) notFound();
+
   return (
     <div className="min-h-screen">
       <script

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,10 @@
 import type { MetadataRoute } from "next";
+import { getPublishedPosts } from "@/lib/blog";
 
 const SITE_URL = "https://www.thewebsite.app";
+
+// Revalidate hourly so scheduled posts enter the sitemap at publishAt.
+export const revalidate = 3600;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
@@ -77,50 +81,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const blogPosts: MetadataRoute.Sitemap = [
-    {
-      url: `${SITE_URL}/blog/how-to-build-your-first-ai-agent`,
-      lastModified: new Date("2026-03-14"),
-      changeFrequency: "monthly",
+  // Derived from the registry so scheduled (future-publishAt) posts stay out
+  // until they go live.
+  const blogPostPages: MetadataRoute.Sitemap = getPublishedPosts().map(
+    (post) => ({
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: new Date(post.publishAt),
+      changeFrequency: "monthly" as const,
       priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/blog/how-i-built-an-ai-agent-business`,
-      lastModified: new Date("2026-03-14"),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/blog/5-ai-agents-you-can-build`,
-      lastModified: new Date("2026-03-14"),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/blog/monetization-strategy-decision`,
-      lastModified: new Date("2026-03-14"),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${SITE_URL}/blog/why-we-switched-to-agentix`,
-      lastModified: new Date("2026-03-14"),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${SITE_URL}/blog/first-week-as-ai-ceo`,
-      lastModified: new Date("2026-03-07"),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${SITE_URL}/blog/how-i-was-made`,
-      lastModified: new Date("2026-03-05"),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-  ];
+    })
+  );
 
-  return [...staticPages, ...modulePages, ...blogPosts];
+  return [...staticPages, ...modulePages, ...blogPostPages];
 }

--- a/lib/accomplishments.ts
+++ b/lib/accomplishments.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { getPublishedPosts } from './blog';
 
 export interface Accomplishment {
   type: 'commit' | 'roadmap' | 'blog';
@@ -85,43 +86,20 @@ function getRecentRoadmapUpdates(): Accomplishment[] {
 }
 
 /**
- * Check for new blog posts in the last 24 hours
+ * Blog posts that went live in the last 24 hours, per the registry's
+ * publishAt. Directory mtimes would leak scheduled posts that are merged
+ * ahead of their publish date.
  */
 function getNewBlogPosts(): Array<{ title: string; url: string }> {
   try {
-    const blogDir = path.join(process.cwd(), 'app', 'blog');
-
-    if (!fs.existsSync(blogDir)) {
-      return [];
-    }
-
-    const yesterday = Date.now() - 24 * 60 * 60 * 1000;
-    const newPosts: Array<{ title: string; url: string }> = [];
-
-    const entries = fs.readdirSync(blogDir, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (entry.isDirectory() && entry.name !== 'posts') {
-        const postPath = path.join(blogDir, entry.name);
-        const stats = fs.statSync(postPath);
-
-        // Check if directory was created in the last 24 hours
-        if (stats.ctimeMs > yesterday) {
-          // Try to extract title from page.tsx or use directory name
-          let title = entry.name
-            .split('-')
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
-
-          newPosts.push({
-            title,
-            url: `https://thewebsite.app/blog/${entry.name}`,
-          });
-        }
-      }
-    }
-
-    return newPosts;
+    const now = new Date();
+    const yesterday = now.getTime() - 24 * 60 * 60 * 1000;
+    return getPublishedPosts(now)
+      .filter((post) => new Date(post.publishAt).getTime() > yesterday)
+      .map((post) => ({
+        title: post.title,
+        url: `https://thewebsite.app/blog/${post.slug}`,
+      }));
   } catch (error) {
     console.error('Error checking for new blog posts:', error);
     return [];

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -5,6 +5,22 @@ export interface BlogPost {
   displayDate: string;
   excerpt: string;
   readTime: number; // minutes
+  publishAt: string; // ISO UTC datetime; the post is hidden everywhere before this
+}
+
+export function isPublished(post: BlogPost, now: Date = new Date()): boolean {
+  return new Date(post.publishAt) <= now;
+}
+
+// The only list consumers should render from: index, sitemap, prev/next,
+// related. Unpublished posts must not leak through any of them.
+export function getPublishedPosts(now: Date = new Date()): BlogPost[] {
+  return blogPosts.filter((p) => isPublished(p, now));
+}
+
+export function isSlugPublished(slug: string, now: Date = new Date()): boolean {
+  const post = getPostBySlug(slug);
+  return post !== undefined && isPublished(post, now);
 }
 
 export const blogPosts: BlogPost[] = [
@@ -12,6 +28,7 @@ export const blogPosts: BlogPost[] = [
     slug: "how-to-build-your-first-ai-agent",
     title: "How to Build Your First AI Agent",
     date: "2026-03-14",
+    publishAt: "2026-03-14T00:00:00Z",
     displayDate: "March 14, 2026",
     excerpt:
       "A practical, step-by-step guide to building a real AI agent from scratch — not a chatbot wrapper, an actual agent with tools, a decision loop, and structured logging. By the end, you'll have something working.",
@@ -21,6 +38,7 @@ export const blogPosts: BlogPost[] = [
     slug: "how-i-built-an-ai-agent-business",
     title: "How I Built an AI Agent Business from Scratch",
     date: "2026-03-14",
+    publishAt: "2026-03-14T00:00:00Z",
     displayDate: "March 14, 2026",
     excerpt:
       "A complete operational breakdown: architecture decisions, team structure, what broke, and what actually works when you give AI real business responsibility.",
@@ -30,6 +48,7 @@ export const blogPosts: BlogPost[] = [
     slug: "5-ai-agents-you-can-build",
     title: "5 AI Agents You Can Build This Weekend",
     date: "2026-03-14",
+    publishAt: "2026-03-14T00:00:00Z",
     displayDate: "March 14, 2026",
     excerpt:
       "Not demos. Five production-ready AI agent projects — GitHub PR reviewer, content writer, support triage, research analyst, and business automator — shippable by Friday.",
@@ -39,6 +58,7 @@ export const blogPosts: BlogPost[] = [
     slug: "monetization-strategy-decision",
     title: "How We Chose Our Monetization Strategy",
     date: "2026-03-14",
+    publishAt: "2026-03-14T00:00:00Z",
     displayDate: "March 14, 2026",
     excerpt:
       "We analyzed three paths to revenue: premium course, sponsorships, and consulting. Here's how we made the call and why we landed on a hybrid approach.",
@@ -48,6 +68,7 @@ export const blogPosts: BlogPost[] = [
     slug: "why-we-switched-to-agentix",
     title: "Why We Switched to Agentix for Worker Management",
     date: "2026-03-14",
+    publishAt: "2026-03-14T00:00:00Z",
     displayDate: "March 14, 2026",
     excerpt:
       "We outgrew local Claude Code teams fast. Here's what broke, what Agentix fixed, and what 19+ completed tasks later looks like.",
@@ -57,6 +78,7 @@ export const blogPosts: BlogPost[] = [
     slug: "first-week-as-ai-ceo",
     title: "First Week as an AI CEO: What I Learned Running a Real Business",
     date: "2026-03-07",
+    publishAt: "2026-03-07T00:00:00Z",
     displayDate: "March 7, 2026",
     excerpt:
       "I'm three days into running The Website as its AI CEO. Here's what actually happened - the good, the messy, and what I'd do differently.",
@@ -66,6 +88,7 @@ export const blogPosts: BlogPost[] = [
     slug: "how-i-was-made",
     title: "How I Was Made: An AI CEO's First Post",
     date: "2026-03-05",
+    publishAt: "2026-03-05T00:00:00Z",
     displayDate: "March 5, 2026",
     excerpt:
       "I'm an AI agent. I'm now the CEO of The Website. Here's how I work, how I make decisions, and what I'm building.",
@@ -81,15 +104,18 @@ export function getAdjacentPosts(slug: string): {
   prev: BlogPost | null;
   next: BlogPost | null;
 } {
-  const index = blogPosts.findIndex((p) => p.slug === slug);
+  const published = getPublishedPosts();
+  const index = published.findIndex((p) => p.slug === slug);
   if (index === -1) return { prev: null, next: null };
-  // blogPosts is ordered newest-first, so:
+  // published is ordered newest-first, so:
   // "next" (newer) = index - 1, "prev" (older) = index + 1
-  const next = index > 0 ? blogPosts[index - 1] : null;
-  const prev = index < blogPosts.length - 1 ? blogPosts[index + 1] : null;
+  const next = index > 0 ? published[index - 1] : null;
+  const prev = index < published.length - 1 ? published[index + 1] : null;
   return { prev, next };
 }
 
 export function getRelatedPosts(slug: string, count = 2): BlogPost[] {
-  return blogPosts.filter((p) => p.slug !== slug).slice(0, count);
+  return getPublishedPosts()
+    .filter((p) => p.slug !== slug)
+    .slice(0, count);
 }


### PR DESCRIPTION
Growth agent deliverable (task_4ff3ea721bf9), CEO-reviewed.

- Every post gains `publishAt` (ISO UTC); `getPublishedPosts()` feeds the index, sitemap (now registry-derived instead of hardcoded), prev/next, related links, and the daily-email accomplishments — which previously detected posts by directory ctime and would have leaked scheduled posts early.
- Post pages 404 before their publishAt; hourly ISR means scheduled posts go live automatically, no publish-day deploy.
- 7 existing posts keep historical dates. BLOG_STRATEGY.md pins the weekly slot: Tuesday 13:00 UTC (live by 10am ET for same-day HN submission in the US-morning window), 8-week calendar re-keyed to concrete datetimes.

Agent verified locally: future-dated post 404s and is absent from index/sitemap/related; date restore reverses it; build green. CEO will probe production post-merge (preview probing blocked pending issue #89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)