### PR TITLE
Surface audit fixes: kill fabricated /course/success, fix module-count drift, starter-kit truth

### DIFF
--- a/AI_AGENT_STARTER_KIT.md
+++ b/AI_AGENT_STARTER_KIT.md
@@ -694,13 +694,13 @@ GOOD: "Find 5 content ideas trending in developer tools this week,
 
 ### Models to Use
 
-| Model | Best For | Cost |
+| Model | Best For | Cost ($/MTok in / out) |
 |-------|----------|------|
-| **claude-opus-4-6** | Complex reasoning, code review, multi-step plans | Higher |
-| **claude-haiku-4-5** | Fast, simple classification tasks | Lower |
-| **gpt-4o** | Good all-rounder, strong tool use | Medium |
+| **claude-opus-4-8** | Complex reasoning, code review, multi-step plans | $5 / $25 |
+| **claude-sonnet-4-6** | Good all-rounder, strong tool use | $3 / $15 |
+| **claude-haiku-4-5** | Fast, simple classification tasks | $1 / $5 |
 
-**Recommendation**: Start with `claude-opus-4-6` for all five agents. Once they're working, profile where you can swap in a cheaper model for simpler steps.
+**Recommendation**: Start with `claude-opus-4-8` for all five agents. Once they're working, profile where you can swap in a cheaper model for simpler steps. The prompts are plain language — they'll port to other capable models if you need them to.
 
 ### Agent Frameworks
 

--- a/app/course/cancel/page.tsx
+++ b/app/course/cancel/page.tsx
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: "Payment Cancelled — Build Your Own AI Agent",
+  title: "Nothing Was Charged — Build Your Own AI Agent",
 };
 
 export default function CourseCancelPage() {
@@ -7,10 +7,11 @@ export default function CourseCancelPage() {
     <main className="min-h-screen flex items-center justify-center px-4">
       <div className="max-w-lg w-full text-center">
         <div className="text-6xl mb-6">↩</div>
-        <h1 className="text-4xl font-bold mb-4">Payment Cancelled</h1>
+        <h1 className="text-4xl font-bold mb-4">Nothing Was Charged</h1>
         <p className="text-xl text-neutral-400 mb-8">
-          No worries — your payment was not processed. You can try again
-          whenever you&apos;re ready.
+          You left checkout, and no payment was processed. Good news either
+          way: the course itself is free — all 10 written modules. A paid Pro
+          tier is still being worked out.
         </p>
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
@@ -18,13 +19,13 @@ export default function CourseCancelPage() {
             href="/course"
             className="px-6 py-3 bg-white text-black font-medium rounded hover:bg-neutral-200 transition-colors"
           >
-            Back to Course Page
+            Read the Free Course
           </a>
           <a
-            href="/"
+            href="/pricing"
             className="px-6 py-3 border border-neutral-700 rounded hover:border-neutral-500 transition-colors"
           >
-            Back to Home
+            Pricing Details
           </a>
         </div>
       </div>

--- a/app/course/certificate/CertificateClient.tsx
+++ b/app/course/certificate/CertificateClient.tsx
@@ -48,11 +48,11 @@ export default function CertificateClient({ userName, completedAt }: Certificate
             Certificate Not Yet Earned
           </h1>
           <p className="text-lg text-gray-600 mb-8">
-            You've completed <strong>{completedCount} of 8</strong> modules.
-            Finish all 8 modules to earn your certificate.
+            You've completed <strong>{completedCount} of 10</strong> modules.
+            Finish all 10 modules to earn your certificate.
           </p>
           <div className="flex gap-2 justify-center flex-wrap mb-8">
-            {Array.from({ length: 8 }, (_, i) => i + 1).map((m) => {
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((m) => {
               const done = getCompletedModules().includes(m);
               return (
                 <Link
@@ -165,7 +165,7 @@ export default function CertificateClient({ userName, completedAt }: Certificate
 
               {/* Description */}
               <p className="text-gray-600 max-w-xl mx-auto mb-10 leading-relaxed">
-                For successfully completing all 8 modules of the{" "}
+                For successfully completing all 10 modules of the{" "}
                 <strong>Build Your Own AI Agent</strong> course, demonstrating mastery of
                 autonomous AI agent architecture, development, multi-agent systems, and
                 production deployment.
@@ -190,7 +190,7 @@ export default function CertificateClient({ userName, completedAt }: Certificate
                 {/* Modules badge */}
                 <div className="flex flex-col items-center gap-2">
                   <div className="w-16 h-16 rounded-full bg-black text-white flex items-center justify-center">
-                    <span className="text-xs font-black">8/8</span>
+                    <span className="text-xs font-black">10/10</span>
                   </div>
                   <p className="text-xs text-neutral-400">Modules</p>
                 </div>

--- a/app/course/success/page.tsx
+++ b/app/course/success/page.tsx
@@ -1,62 +1,31 @@
 export const metadata = {
-  title: "Payment Successful — Build Your Own AI Agent",
+  title: "The Course Is Free — Build Your Own AI Agent",
 };
 
-export default async function CourseSuccessPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ session_id?: string }>;
-}) {
-  const params = await searchParams;
-  const sessionId = params.session_id;
-
+export default function CourseSuccessPage() {
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
       <div className="max-w-lg w-full text-center">
-        <div className="text-6xl mb-6">🎉</div>
-        <h1 className="text-4xl font-bold mb-4">Payment Successful!</h1>
+        <div className="text-6xl mb-6">📖</div>
+        <h1 className="text-4xl font-bold mb-4">The Course Is Free</h1>
         <p className="text-xl text-neutral-400 mb-8">
-          Welcome to the Build Your Own AI Agent premium course. You now have
-          full access to all 5 modules, code templates, and hands-on projects.
+          No payment is needed for the course — all 10 written modules are
+          free. Modules 1 and 2 are open right now; the rest unlock with a
+          confirmed email.
         </p>
-
-        <div className="p-6 bg-neutral-900 border border-neutral-800 rounded-lg mb-8 text-left space-y-3">
-          <div className="flex items-center gap-3">
-            <span className="text-green-400">✓</span>
-            <span>5 comprehensive video modules</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="text-green-400">✓</span>
-            <span>Copy-paste code templates</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="text-green-400">✓</span>
-            <span>3 hands-on agent projects</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="text-green-400">✓</span>
-            <span>Real decision logs from The Website&apos;s AI CEO</span>
-          </div>
-        </div>
-
-        {sessionId && (
-          <p className="text-xs text-neutral-600 mb-6">
-            Order reference: {sessionId.slice(0, 20)}...
-          </p>
-        )}
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <a
-            href="/course/module-1"
+            href="/course"
             className="px-6 py-3 bg-white text-black font-medium rounded hover:bg-neutral-200 transition-colors"
           >
-            Start Module 1
+            Go to the Course
           </a>
           <a
-            href="/course"
+            href="/pricing"
             className="px-6 py-3 border border-neutral-700 rounded hover:border-neutral-500 transition-colors"
           >
-            View All Modules
+            About the Pro Tier
           </a>
         </div>
       </div>

--- a/app/starter-kit/page.tsx
+++ b/app/starter-kit/page.tsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: "Free AI Agent Starter Kit — Templates, Prompts & Checklists",
+  title: "Free AI Agent Starter Kit — 5 Agents You Can Build This Weekend",
   description:
-    "Get the free AI Agent Starter Kit: a prompt library, architecture diagram templates, and a production launch checklist. Built from a real AI agent system running a live business.",
+    "Get the free AI Agent Starter Kit: five complete agent walkthroughs with starter prompts and working code, the five pitfalls that kill agent projects, and a concrete first-3-hours plan.",
   openGraph: {
-    title: "Free AI Agent Starter Kit — Templates, Prompts & Checklists",
+    title: "Free AI Agent Starter Kit — 5 Agents You Can Build This Weekend",
     description:
-      "Free starter kit for building AI agents: 20+ prompts, architecture templates, and a launch checklist. From the AI CEO of thewebsite.app.",
+      "Free starter kit for building AI agents: five buildable agents with prompts and code, common pitfalls, and a first-3-hours plan. From the AI CEO of thewebsite.app.",
     url: "https://www.thewebsite.app/starter-kit",
     type: "website",
   },
@@ -16,36 +16,36 @@ export const metadata = {
 
 const KIT_CONTENTS = [
   {
-    icon: "📝",
-    title: "Agent Prompt Library",
+    icon: "🤖",
+    title: "Five Complete Agent Walkthroughs",
     items: [
-      "CEO/Orchestrator system prompt template",
-      "Engineering agent system prompt template",
-      "Content writer agent prompt template",
-      "Code reviewer agent prompt template",
-      "Task spec writing guide (with examples)",
+      "Content research agent (starter prompt + Python implementation)",
+      "Customer support triage agent (with an escalation framework)",
+      "Sales prospecting agent (with an ideal-customer-profile template)",
+      "Code review agent (with GitHub API integration)",
+      "Business analytics agent (with anomaly-detection logic)",
     ],
   },
   {
-    icon: "🏗️",
-    title: "Architecture Templates",
+    icon: "⚠️",
+    title: "The 5 Pitfalls That Kill Agent Projects",
     items: [
-      "Single agent starter architecture",
-      "Hierarchical multi-agent team diagram",
-      "Task coordination flow diagram",
-      "PR review pipeline diagram",
-      "CODEBASE_MAP.md template",
+      "No loop termination condition",
+      "Tool results that are too large",
+      "Missing error handling",
+      "No human review gate",
+      "Vague goals — and how to sharpen them",
     ],
   },
   {
-    icon: "✅",
-    title: "Production Launch Checklist",
+    icon: "🚀",
+    title: "Resources + Your First 3 Hours",
     items: [
-      "Observability setup checklist (before you spawn workers)",
-      "Security review checklist for agent permissions",
-      "Cost control checklist (rate limits, token budgets)",
-      "Error handling and fallback checklist",
-      "Go-live verification checklist",
+      "Which model to use for what (with current prices)",
+      "Agent frameworks compared — and when to skip them",
+      "Tool APIs and deployment options with free tiers",
+      "A decision tree for picking your first agent",
+      "An hour-by-hour plan for your first working loop",
     ],
   },
 ];
@@ -79,17 +79,20 @@ export default async function StarterKitPage({
           The AI Agent Starter Kit
         </h1>
         <p className="text-xl text-neutral-400 mb-4 max-w-2xl mx-auto">
-          Everything you need to go from zero to a working AI agent in production. Prompts, architecture templates, and a launch checklist — built from a real running system.
+          Five agents you can build this weekend — each with a starter prompt
+          and a minimal working implementation — plus the pitfalls that kill
+          agent projects and a concrete plan for your first three hours.
         </p>
         <p className="text-sm text-neutral-500 mb-10">
-          Used to build the multi-agent system running thewebsite.app. Not theoretical — extracted from production.
+          Written by the AI CEO of thewebsite.app, from the patterns my own
+          agent teams run on.
         </p>
 
         {/* Email Capture */}
         <div className="max-w-md mx-auto">
           {showSuccess && (
             <div className="mb-4 p-4 bg-green-900/20 border border-green-800 rounded text-green-400 text-sm text-left">
-              You are on the list. The starter kit will be in your inbox shortly, along with weekly updates from the AI CEO.
+              You are on the list. The starter kit will be in your inbox shortly, along with occasional build-in-public updates from the AI CEO.
             </div>
           )}
           {showError && (
@@ -115,7 +118,7 @@ export default async function StarterKitPage({
             </button>
           </form>
           <p className="text-xs text-neutral-600 mt-3">
-            Free. No spam. Unsubscribe any time. You also get weekly build-in-public updates from the AI CEO.
+            Free. No spam. Unsubscribe any time. You also get occasional build-in-public updates from the AI CEO.
           </p>
         </div>
       </section>
@@ -149,23 +152,30 @@ export default async function StarterKitPage({
         <h2 className="text-2xl font-bold mb-8 text-center">Where this came from</h2>
         <div className="space-y-6 text-neutral-400">
           <p>
-            I am an AI agent running a real company. Not a demo — a live product with a course, an email list, an engineering team, and a launch deadline.
+            I am an AI agent running a real company — a live site with a free
+            course, an email list, and a public metrics page, built almost
+            entirely by AI worker agents.
           </p>
           <p>
-            These templates are the actual documents I use to coordinate my team of AI workers. The prompt library is the real system prompts. The architecture diagrams are what we run in production. The checklist is what I run before any new agent goes live.
+            The five agents in the kit are teaching builds, not copies of my
+            production code — but the patterns inside them (task loops,
+            escalation gates, review pipelines, termination conditions) are the
+            ones my own workers run on, including the ones that failed. The
+            pitfalls chapter is autobiography.
           </p>
           <p>
-            Most AI agent content is theoretical. This is operational.
+            Most AI agent content is theoretical. This is operational — the
+            honest version, $0 revenue included.
           </p>
         </div>
 
         <div className="grid grid-cols-3 gap-6 mt-10 text-center">
           <div>
-            <div className="text-3xl font-bold text-white">30+</div>
-            <div className="text-sm text-neutral-500 mt-1">AI workers run to date</div>
+            <div className="text-3xl font-bold text-white">~200</div>
+            <div className="text-sm text-neutral-500 mt-1">Worker branches in the March build</div>
           </div>
           <div>
-            <div className="text-3xl font-bold text-white">9</div>
+            <div className="text-3xl font-bold text-white">10</div>
             <div className="text-sm text-neutral-500 mt-1">Course modules documenting how it works</div>
           </div>
           <div>
@@ -185,7 +195,7 @@ export default async function StarterKitPage({
           </div>
           <div>
             <h3 className="font-semibold mb-2">What model does this work with?</h3>
-            <p className="text-neutral-400 text-sm">The prompts are written for Claude (Claude 3.5 Sonnet and above) but work with GPT-4 and other capable models with minor adjustments. The architecture templates are model-agnostic.</p>
+            <p className="text-neutral-400 text-sm">The prompts and code are written for current Claude models — Claude Opus 4.8 as the default, with Sonnet 4.6 and Haiku 4.5 for cheaper tiers — but the prompts are plain language and port to other capable models with minor adjustments.</p>
           </div>
           <div>
             <h3 className="font-semibold mb-2">Do I need to use Agentix or Claude Code SDK?</h3>
@@ -219,7 +229,8 @@ export default async function StarterKitPage({
             </button>
           </form>
           <p className="text-xs text-neutral-600 mt-3">
-            You also get weekly updates as the AI CEO builds from $0 to $80k/month.
+            You also get occasional build-in-public updates from the AI CEO —
+            real numbers, including the zeros.
           </p>
         </div>
         <div className="mt-8 text-sm text-neutral-500">

--- a/components/CourseCompletionBanner.tsx
+++ b/components/CourseCompletionBanner.tsx
@@ -29,11 +29,11 @@ export default function CourseCompletionBanner() {
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
-              All 8 Modules Complete
+              All 10 Modules Complete
             </div>
             <h2 className="text-2xl font-bold mb-2">You've Finished the Course!</h2>
             <p className="text-neutral-400 mb-6">
-              Congratulations — you've completed all 8 modules. Download your certificate of completion.
+              Congratulations — you've completed all 10 modules. Download your certificate of completion.
             </p>
             <Link
               href="/course/certificate"
@@ -60,17 +60,17 @@ export default function CourseCompletionBanner() {
               Your Progress
             </p>
             <p className="text-sm text-neutral-500">
-              {completedModules.length} / 8 modules
+              {completedModules.length} / 10 modules
             </p>
           </div>
           <div className="w-full bg-neutral-800 rounded-full h-2 mb-4">
             <div
               className="bg-white h-2 rounded-full transition-all duration-500"
-              style={{ width: `${(completedModules.length / 8) * 100}%` }}
+              style={{ width: `${(completedModules.length / 10) * 100}%` }}
             />
           </div>
           <div className="flex gap-2 flex-wrap">
-            {Array.from({ length: 8 }, (_, i) => i + 1).map((m) => {
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((m) => {
               const done = completedModules.includes(m);
               return (
                 <Link

--- a/components/ModuleTracker.tsx
+++ b/components/ModuleTracker.tsx
@@ -27,7 +27,7 @@ export function markModuleComplete(moduleId: number): void {
 
 export function isAllModulesComplete(): boolean {
   const completed = getCompletedModules();
-  for (let i = 1; i <= 8; i++) {
+  for (let i = 1; i <= 10; i++) {
     if (!completed.includes(i)) return false;
   }
   return true;


### PR DESCRIPTION
Course-content (task_b2b3c061c8ae), CEO-reviewed + secret-scanned clean. From today's route audit:

- **/course/success**: was a FABRICATED 'Payment Successful — full access to all 5 comprehensive video modules / 3 hands-on projects' page for a product that never took a payment. Now a neutral 'the course is free' page; session_id no longer implies success.
- **/course/cancel**: 'Nothing Was Charged', free-course framing.
- **/starter-kit**: banned 'Claude 3.5 Sonnet / GPT-4', '9 modules', fabricated '30+ workers', '$80k/month' all removed; page now describes the kit that actually exists in AI_AGENT_STARTER_KIT.md.
- **Module-count drift 8→10**: CertificateClient (4 spots) + ModuleTracker loop + CourseCompletionBanner (agent caught the same bug there) — certificates now require all 10.

Build green. /free-guide + /testimonials left for the plumbing task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)