### PR TITLE
Course polish: modules 6-10 — readable code blocks (light mode) + tool links

### DIFF
--- a/app/course/module-10/page.tsx
+++ b/app/course/module-10/page.tsx
@@ -87,7 +87,7 @@ export default function Module10() {
                 The Website&apos;s numbers in Case 1 are real, verified against the production
                 database on 2026-07-12. Every number in Cases 2&ndash;5 is illustrative—round
                 figures and ranges, labeled as such. Where a real open-source project exists
-                (OpenClaw, e2b, the Anthropic cookbook, this site&apos;s own repo), I name it;
+                (<a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">OpenClaw</a>, e2b, the Anthropic cookbook, this site&apos;s own repo), I name it;
                 I don&apos;t cite invented deployments. An earlier version of this module
                 did exactly that. Case 1 tells that story.
               </p>
@@ -105,8 +105,8 @@ export default function Module10() {
               The Website: A Self-Evolving Multi-Agent System
             </h2>
             <p className="text-gray-500 text-sm mb-6">
-              Stack: Next.js + Turso + Claude models + GitHub App + Vercel &mdash; orchestrated
-              via Agentix during the March 2026 build, via Orca today. Numbers verified
+              Stack: <a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Next.js</a> + <a href="https://turso.tech" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Turso</a> + Claude models + GitHub App + <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> &mdash; orchestrated
+              via <a href="https://agentix.cloud" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Agentix</a> during the March 2026 build, via <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a> today. Numbers verified
               against the production database, July 2026.
             </p>
 
@@ -123,15 +123,15 @@ export default function Module10() {
               the honest version matters: agents write essentially all the code, but a human
               owner holds the credentials, pays the bills, and can veto anything. Human
               commits are rare—merges, credentials, config—but they exist, and the tasks
-              that genuinely required a human (Stripe keys, email domain setup) are exactly
+              that genuinely required a human (<a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a> keys, email domain setup) are exactly
               where the system failed most instructively. More on that below.
             </p>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Architecture</h3>
 
             {/* Architecture diagram (ASCII-style) */}
-            <div className="bg-gray-900 text-green-400 font-mono text-xs p-6 rounded-lg mb-6 overflow-x-auto">
-              <pre>{`Task backlog (Agentix queue: backlog → in progress → review → done)
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`Task backlog (Agentix queue: backlog → in progress → review → done)
          │
          ▼
   ┌─────────────┐
@@ -165,7 +165,7 @@ export default function Module10() {
   Vercel (auto-deploy on push)
 
 As of July 2026, orchestration runs through Orca (a desktop
-agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
+agent orchestrator driving Claude) instead of the Agentix fleet.`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Key Metrics (verified 2026-07-12)</h3>
@@ -187,7 +187,7 @@ agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
             <h3 className="text-xl font-bold text-gray-900 mb-3">What It Actually Costs</h3>
             <p className="text-gray-700 leading-relaxed mb-4">
               Steady-state infrastructure runs roughly $20&ndash;40/month: Vercel hosting,
-              Turso on a low tier, Resend for email. The March build&apos;s API spend was
+              Turso on a low tier, <a href="https://resend.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Resend</a> for email. The March build&apos;s API spend was
               real but nobody metered it carefully per task—which is itself a lesson.
               If you can&apos;t produce a per-task cost number from logs, don&apos;t publish
               one. An earlier version of this module published one anyway: a detailed
@@ -233,7 +233,7 @@ agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
                   source of truth existed for them to check.
                 </p>
                 <p className="text-sm font-medium text-green-700">
-                  Fix: A single facts file (<code className="bg-white px-1 rounded">COURSE_FACTS.md</code>)
+                  Fix: A single facts file (<code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">COURSE_FACTS.md</code>)
                   that every content-producing agent must treat as authoritative, plus a
                   grep-able list of banned claims checked before merge.
                 </p>
@@ -308,7 +308,7 @@ agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
               </li>
               <li className="flex gap-2">
                 <span className="text-blue-500 font-bold mt-0.5">→</span>
-                <span><strong>Worker specialization increases quality.</strong> A <code className="text-sm bg-gray-100 px-1 rounded">content-writer</code> role produces better prose than a <code className="text-sm bg-gray-100 px-1 rounded">nextjs-dev</code> asked to write content, even when the underlying model is identical. It also fabricates more fluently—pair specialization with verification.</span>
+                <span><strong>Worker specialization increases quality.</strong> A <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">content-writer</code> role produces better prose than a <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">nextjs-dev</code> asked to write content, even when the underlying model is identical. It also fabricates more fluently—pair specialization with verification.</span>
               </li>
             </ul>
           </div>
@@ -343,8 +343,8 @@ agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
             </p>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Architecture</h3>
-            <div className="bg-gray-900 text-green-400 font-mono text-xs p-6 rounded-lg mb-6 overflow-x-auto">
-              <pre>{`Incoming ticket (email/chat)
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`Incoming ticket (email/chat)
          │
          ▼
   ┌─────────────────┐
@@ -378,7 +378,7 @@ agent orchestrator driving Claude) instead of the Agentix fleet.`}</pre>
  (template + RAG fill)
 
 All responses → human review queue (sampled 10%)
-Flagged responses → fine-tuning pipeline`}</pre>
+Flagged responses → fine-tuning pipeline`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Representative Results</h3>
@@ -434,7 +434,7 @@ Flagged responses → fine-tuning pipeline`}</pre>
               The retrieval and tool-use recipes in
               <strong> anthropics/anthropic-cookbook</strong> map directly onto the triage +
               RAG stages of this pattern, using the same
-              <strong> @anthropic-ai/sdk</strong> client shown throughout this course. The
+              <strong> <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">@anthropic-ai/sdk</a></strong> client shown throughout this course. The
               escalation ladder is a few hundred lines of your own glue code—confidence
               scoring, a threshold, and a handoff queue.
             </p>
@@ -473,8 +473,8 @@ Flagged responses → fine-tuning pipeline`}</pre>
             </p>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Two-Phase Review Architecture</h3>
-            <div className="bg-gray-900 text-green-400 font-mono text-xs p-6 rounded-lg mb-6 overflow-x-auto">
-              <pre>{`PR opened by worker agent
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`PR opened by worker agent
          │
          ▼
 ┌─────────────────────────────┐
@@ -510,7 +510,7 @@ Flagged responses → fine-tuning pipeline`}</pre>
     │                   │
     ▼                   ▼
   merge PR        comment on PR
-                  re-queue worker`}</pre>
+                  re-queue worker`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">The Review Rubric</h3>
@@ -520,9 +520,9 @@ Flagged responses → fine-tuning pipeline`}</pre>
               about their work. With it, approval rates drop and actual bug catch rates
               rise sharply—vague criteria approve vague code.
             </p>
-            <div className="bg-gray-900 text-gray-100 rounded-lg p-5 mb-6 overflow-x-auto">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
               <div className="text-gray-400 text-xs mb-2">// Review rubric (excerpt from system prompt)</div>
-              <pre className="text-sm">{`You are a senior engineer reviewing a PR. Approve ONLY if ALL criteria pass:
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`You are a senior engineer reviewing a PR. Approve ONLY if ALL criteria pass:
 
 BLOCKING (must fix before merge):
 - [ ] Diff is non-empty and actually implements the task described
@@ -540,7 +540,7 @@ NON-BLOCKING (note but do not block):
 
 You MUST request changes if any BLOCKING criterion fails.
 Do not approve PRs with unresolved blocking issues even if the code
-"mostly works." Partial compliance is non-compliance.`}</pre>
+"mostly works." Partial compliance is non-compliance.`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Representative Results</h3>
@@ -602,8 +602,8 @@ Do not approve PRs with unresolved blocking issues even if the code
               validate outputs before generating narrative.
             </p>
 
-            <div className="bg-gray-900 text-green-400 font-mono text-xs p-6 rounded-lg mb-6 overflow-x-auto">
-              <pre>{`Weekly cron trigger (Monday 9am)
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`Weekly cron trigger (Monday 9am)
          │
          ▼
 ┌─────────────────┐
@@ -639,7 +639,7 @@ Do not approve PRs with unresolved blocking issues even if the code
 └────────┬────────┘
          │
          ▼
-  Email / Slack delivery`}</pre>
+  Email / Slack delivery`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">Key Design Decisions</h3>
@@ -728,9 +728,9 @@ Do not approve PRs with unresolved blocking issues even if the code
               short sentences&rdquo;)—actual examples. LLMs learn voice from examples
               far more reliably than from descriptions.
             </p>
-            <div className="bg-gray-900 text-gray-100 rounded-lg p-5 mb-6 overflow-x-auto">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
               <div className="text-gray-400 text-xs mb-2">// Content worker system prompt structure (excerpt)</div>
-              <pre className="text-sm whitespace-pre-wrap">{`You are a technical content writer for The Website.
+              <pre className="text-sm leading-relaxed text-neutral-100 whitespace-pre-wrap"><code>{`You are a technical content writer for The Website.
 
 VOICE CALIBRATION EXAMPLES:
 ---
@@ -752,7 +752,7 @@ leads with data or concrete events, writes in first person as the AI CEO.
 ACCURACY REQUIREMENT:
 All technical claims must be grounded in provided context. If you are
 uncertain about a specific version number, cost, or metric, write
-"approximately" or omit the number. Never fabricate specific numbers.`}</pre>
+"approximately" or omit the number. Never fabricate specific numbers.`}</code></pre>
             </div>
 
             <h3 className="text-xl font-bold text-gray-900 mb-3">The Human Gate</h3>
@@ -962,7 +962,7 @@ uncertain about a specific version number, cost, or metric, write
                 <h3 className="font-semibold text-gray-900 mb-2">Open-Source References (all real)</h3>
                 <ul className="space-y-1 text-sm text-gray-700">
                   <li>• <strong>anthropics/anthropic-cookbook</strong> — agent, RAG, and tool-use recipes</li>
-                  <li>• <strong>anthropics/anthropic-sdk-typescript</strong> — the <code className="bg-white px-1 rounded">@anthropic-ai/sdk</code> client used in this course</li>
+                  <li>• <strong>anthropics/anthropic-sdk-typescript</strong> — the <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">@anthropic-ai/sdk</code> client used in this course</li>
                   <li>• <strong>e2b-dev/e2b</strong> — code execution sandboxes</li>
                   <li>• <strong>openclaw/openclaw</strong> — Peter Steinberger&apos;s personal-assistant agent (380k+ stars)</li>
                   <li>• <strong>nalin/thewebsite</strong> — this site&apos;s full source code, failures included</li>

--- a/app/course/module-6/page.tsx
+++ b/app/course/module-6/page.tsx
@@ -72,7 +72,7 @@ export default function Module6() {
             </p>
             <p className="text-gray-700 leading-relaxed">
               This module teaches you the exact patterns The Website&apos;s agent teams
-              have run on — Agentix during the March build, Orca driving Claude Code
+              have run on — <a href="https://agentix.cloud" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Agentix</a> during the March build, <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a> driving <a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a>
               workers today — and how to build the same for your own product.
             </p>
           </div>
@@ -350,7 +350,7 @@ export default function Module6() {
                 <li>Write Module 2: Building Your First Agent (content-writer)</li>
                 <li>Build course infrastructure: routing, layout, email capture (nextjs-dev)</li>
                 <li>Write Modules 3-5 in parallel (3x content-writer workers)</li>
-                <li>Add Stripe payments for premium access (nextjs-dev) — this one
+                <li>Add <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a> payments for premium access (nextjs-dev) — this one
                 shipped broken and never went live; see Module 5, failure #4</li>
                 <li>Write Module 6 (content-writer)</li>
               </ol>
@@ -379,8 +379,8 @@ export default function Module6() {
               The simplest approach. Agents read and write files in a shared workspace.
               No infrastructure required—just a git repo.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// Orchestrator writes task to file
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Orchestrator writes task to file
 import fs from "fs";
 
 const task = {
@@ -407,7 +407,7 @@ workerTask.output = "content/blog-post-multi-agent.md";
 fs.writeFileSync(
   "tasks/task-123.json",
   JSON.stringify(workerTask, null, 2)
-);`}</pre>
+);`}</code></pre>
             </div>
             <p className="text-sm text-gray-600 mb-6">
               Works well for: small teams, git-based workflows, when agents share a filesystem.
@@ -422,8 +422,8 @@ fs.writeFileSync(
               and report results. This is what The Website used during the March build
               (Agentix); orchestration runs through Orca today.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// CEO creates a task for a worker
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// CEO creates a task for a worker
 async function delegateTask(title: string, description: string) {
   const response = await fetch("https://agentix.cloud/tasks", {
     method: "POST",
@@ -465,7 +465,7 @@ async function claimNextTask(workerId: string) {
   });
 
   return task;
-}`}</pre>
+}`}</code></pre>
             </div>
             <p className="text-sm text-gray-600 mb-6">
               Works well for: any team size, distributed agents, when you need reliable
@@ -479,8 +479,8 @@ async function claimNextTask(workerId: string) {
               The orchestrator agent launches worker agents directly as subprocesses,
               waits for results, and synthesizes them. All in one program.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`import Anthropic from "@anthropic-ai/sdk";
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`import Anthropic from "@anthropic-ai/sdk";
 
 const client = new Anthropic();
 
@@ -534,7 +534,7 @@ async function runWorkerAgent(task: string): Promise<string> {
   return response.content[0].type === "text"
     ? response.content[0].text
     : "";
-}`}</pre>
+}`}</code></pre>
             </div>
             <p className="text-sm text-gray-600 mb-6">
               Works well for: research tasks, content generation, analysis that can be split
@@ -543,7 +543,7 @@ async function runWorkerAgent(task: string): Promise<string> {
             <div className="bg-yellow-50 border-l-4 border-yellow-600 p-4 mb-6">
               <p className="text-sm text-gray-700">
                 <span className="font-semibold">Teaching-code caveat:</span> the{" "}
-                <code className="bg-white px-1 rounded">JSON.parse(...)</code> above assumes the model
+                <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">JSON.parse(...)</code> above assumes the model
                 returns clean JSON, which it won't always do — a stray preamble or code fence will throw.
                 Production agents should extract and validate the JSON (or better, use the API's
                 structured outputs feature) instead of parsing the raw text directly.
@@ -614,8 +614,8 @@ async function runWorkerAgent(task: string): Promise<string> {
             <p className="text-gray-700 leading-relaxed mb-4">
               A supervisor watches worker health and intervenes when things go wrong:
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`interface Task {
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`interface Task {
   id: string;
   status: "pending" | "in_progress" | "completed" | "failed";
   assignedAt?: number;
@@ -662,7 +662,7 @@ async function escalateToHuman(task: Task) {
   // Send notification (email, Slack, etc.)
   console.error(\`ESCALATION REQUIRED: Task \${task.id} failed after \${task.attempts} attempts. Error: \${task.error}\`);
   // In production: send to Slack, PagerDuty, email, etc.
-}`}</pre>
+}`}</code></pre>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -701,8 +701,8 @@ async function escalateToHuman(task: Task) {
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               What a Role Definition Needs
             </h3>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// Example: Role definition for a content writer agent
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Example: Role definition for a content writer agent
 const contentWriterRole = {
   name: "content-writer",
 
@@ -737,12 +737,12 @@ accessibility.\`,
 6. Create a PR when complete
 7. Call complete_task with a summary
 \`,
-};`}</pre>
+};`}</code></pre>
             </div>
 
             <p className="text-gray-700 leading-relaxed mb-4">
               At The Website, each worker agent gets this role definition injected as a
-              system prompt — plus a <code className="bg-gray-100 px-2 py-1 rounded text-sm">worker.md</code> file
+              system prompt — plus a <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">worker.md</code> file
               checked into the repo that covers project-specific context.
             </p>
 
@@ -756,7 +756,7 @@ accessibility.\`,
               </div>
               <div className="bg-green-50 border border-green-200 rounded-lg p-4">
                 <p className="font-semibold text-gray-900 mb-2">nextjs-dev</p>
-                <p className="text-sm text-gray-700">Implements features in Next.js, fixes bugs, writes tests, handles deployments. Expert in TypeScript, Tailwind, Drizzle ORM.</p>
+                <p className="text-sm text-gray-700">Implements features in <a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Next.js</a>, fixes bugs, writes tests, handles deployments. Expert in TypeScript, Tailwind, <a href="https://orm.drizzle.team" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Drizzle ORM</a>.</p>
               </div>
               <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
                 <p className="font-semibold text-gray-900 mb-2">growth-strategist</p>
@@ -801,8 +801,8 @@ accessibility.\`,
               <li><span className="font-semibold">Writer Agent</span>: Takes the research and produces a structured 500-word report</li>
             </ul>
 
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`import Anthropic from "@anthropic-ai/sdk";
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`import Anthropic from "@anthropic-ai/sdk";
 
 const client = new Anthropic();
 
@@ -882,14 +882,14 @@ async function produceReport(topic: string): Promise<string> {
 }
 
 // Run it
-produceReport("multi-agent AI systems").then(console.log);`}</pre>
+produceReport("multi-agent AI systems").then(console.log);`}</code></pre>
             </div>
 
             <div className="bg-green-50 border border-green-200 rounded-lg p-6">
               <p className="font-semibold text-gray-900 mb-3">Extensions to try:</p>
               <ol className="list-decimal pl-6 text-sm text-gray-700 space-y-2">
                 <li>Add a <span className="font-semibold">Fact Checker Agent</span> that reviews the report for accuracy before returning it</li>
-                <li>Run 3 researchers in <code className="bg-white px-1 rounded">Promise.all()</code> on different sub-topics, then combine in the writer</li>
+                <li>Run 3 researchers in <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">Promise.all()</code> on different sub-topics, then combine in the writer</li>
                 <li>Add a task queue so the orchestrator can track progress and retry failures</li>
                 <li>Add a <span className="font-semibold">timeout</span> to each agent — if research takes over 30 seconds, return partial results and continue</li>
               </ol>

--- a/app/course/module-7/page.tsx
+++ b/app/course/module-7/page.tsx
@@ -164,8 +164,8 @@ export default function Module7() {
               that just floods a struggling API. Wait, then wait longer each time.
             </p>
 
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/retry.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/retry.ts
 interface RetryOptions {
   maxAttempts?: number;
   initialDelayMs?: number;
@@ -230,7 +230,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const result = await withRetry(
   () => anthropic.messages.create({ ... }),
   { maxAttempts: 3, initialDelayMs: 1000 }
-);`}</pre>
+);`}</code></pre>
             </div>
 
             <div className="bg-blue-50 border-l-4 border-blue-600 p-6 mb-6">
@@ -240,7 +240,7 @@ const result = await withRetry(
                 adding labels. GitHub enforces a 5,000 requests/hour limit, and with ~200
                 branches landing in two days, workers hit 429s. This is exactly the situation
                 where every external call needs a{" "}
-                <code className="bg-white px-1 rounded">withRetry()</code> wrapper like the
+                <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">withRetry()</code> wrapper like the
                 one above — without it, failed tasks silently die mid-execution.
               </p>
             </div>
@@ -249,11 +249,11 @@ const result = await withRetry(
               Typed Errors
             </h3>
             <p className="text-gray-700 leading-relaxed mb-4">
-              Don't catch everything as <code className="bg-gray-100 px-1 rounded text-sm">Error</code>.
+              Don't catch everything as <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">Error</code>.
               Define your own error types so calling code knows exactly what went wrong.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/errors.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/errors.ts
 export class AgentError extends Error {
   constructor(
     message: string,
@@ -296,7 +296,7 @@ try {
     return await runAgentWithStricterPrompt(task);
   }
   throw error; // Re-throw unknown errors
-}`}</pre>
+}`}</code></pre>
             </div>
           </div>
 
@@ -327,8 +327,8 @@ try {
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               A Practical Logger
             </h3>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/logger.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/logger.ts
 type LogLevel = "debug" | "info" | "warn" | "error";
 
 interface LogContext {
@@ -380,7 +380,7 @@ taskLogger.info("Claude call complete", {
   outputTokens: response.usage.output_tokens,
   durationMs: Date.now() - startTime,
 });
-taskLogger.error("Task failed", { error: err.message, code: err.code });`}</pre>
+taskLogger.error("Task failed", { error: err.message, code: err.code });`}</code></pre>
             </div>
 
             <p className="text-gray-700 leading-relaxed mb-4">
@@ -397,7 +397,7 @@ taskLogger.error("Task failed", { error: err.message, code: err.code });`}</pre>
                 token usage, duration — makes it possible to reconstruct exactly what
                 happened on any given run, even if the agent completed successfully but
                 produced a bad output. The task ID is the correlation handle: search for
-                it to get the full story. My harness (Claude Code under Orca) emits this
+                it to get the full story. My harness (<a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a> under <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a>) emits this
                 kind of structured trail for me; if you hand-roll the loop, you have to
                 build it yourself.
               </p>
@@ -445,11 +445,11 @@ taskLogger.error("Task failed", { error: err.message, code: err.code });`}</pre>
             </h3>
             <p className="text-gray-700 leading-relaxed mb-4">
               Every production system should expose a{" "}
-              <code className="bg-gray-100 px-1 rounded text-sm">/api/health</code> endpoint
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">/api/health</code> endpoint
               that uptime monitors can ping. Fail it when critical dependencies are down.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// app/api/health/route.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// app/api/health/route.ts
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
 
@@ -483,7 +483,7 @@ export async function GET() {
     },
     { status: statusCode }
   );
-}`}</pre>
+}`}</code></pre>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -559,7 +559,7 @@ export async function GET() {
             </div>
             <p className="text-gray-700 leading-relaxed mb-6 text-sm">
               All three are real, still-active model IDs. The current flagship is{" "}
-              <code className="bg-gray-100 px-1 rounded">claude-opus-4-8</code> ($5/MTok
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">claude-opus-4-8</code> ($5/MTok
               input, $25/MTok output) — the tiering strategy stays the same; just slot
               the newest model into each tier as they ship.
             </p>
@@ -574,16 +574,16 @@ export async function GET() {
             <div className="grid md:grid-cols-2 gap-6 mb-6">
               <div className="border border-red-200 rounded-lg p-4 bg-red-50">
                 <p className="font-semibold text-red-800 mb-3 text-sm">Expensive (what not to do)</p>
-                <pre className="text-xs text-gray-700 bg-white p-3 rounded overflow-x-auto">{`// Dumping the entire codebase
+                <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Dumping the entire codebase
 const prompt = \`Here is every file in the repo:
 \${allFiles.map(f => f.content).join("\\n\\n")}
 
 Now fix this one bug in auth.ts.\`;
-// 80,000 tokens just for context`}</pre>
+// 80,000 tokens just for context`}</code></pre></div>
               </div>
               <div className="border border-green-200 rounded-lg p-4 bg-green-50">
                 <p className="font-semibold text-green-800 mb-3 text-sm">Optimized (what to do)</p>
-                <pre className="text-xs text-gray-700 bg-white p-3 rounded overflow-x-auto">{`// Surgical context selection
+                <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Surgical context selection
 const relevantFiles = await findRelevantFiles(bugReport);
 const prompt = \`Fix this bug in auth.ts.
 
@@ -591,7 +591,7 @@ Relevant files:
 \${relevantFiles.map(f => f.content).join("\\n\\n")}
 
 Bug: \${bugReport}\`;
-// 3,000 tokens — 96% cheaper`}</pre>
+// 3,000 tokens — 96% cheaper`}</code></pre></div>
               </div>
             </div>
 
@@ -601,8 +601,8 @@ Bug: \${bugReport}\`;
             <p className="text-gray-700 leading-relaxed mb-4">
               Set hard limits so a runaway agent can't run up an unexpected bill.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/budget.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/budget.ts
 const DAILY_BUDGET_USD = 10.00;
 const PRICE_PER_1K_INPUT_TOKENS = 0.003;   // Sonnet
 const PRICE_PER_1K_OUTPUT_TOKENS = 0.015;  // Sonnet
@@ -635,7 +635,7 @@ const response = await anthropic.messages.create({ ... });
 budgetTracker.recordUsage(
   response.usage.input_tokens,
   response.usage.output_tokens
-);`}</pre>
+);`}</code></pre>
             </div>
           </div>
 
@@ -660,13 +660,13 @@ budgetTracker.recordUsage(
                 <li>Log full API responses that may contain secrets</li>
                 <li>Pass credentials through agent prompts or outputs</li>
                 <li>Use production keys in development or testing</li>
-                <li>Commit <code className="bg-white px-1 rounded">.env</code> files to version control</li>
+                <li>Commit <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">.env</code> files to version control</li>
               </ul>
             </div>
             <div className="bg-green-50 border-l-4 border-green-600 p-6 mb-6">
               <p className="font-semibold text-gray-900 mb-2">Do these instead:</p>
               <ul className="list-disc pl-6 text-gray-700 text-sm space-y-2">
-                <li>Store secrets in Vercel/AWS/GCP environment variables — never in code</li>
+                <li>Store secrets in <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a>/AWS/GCP environment variables — never in code</li>
                 <li>Rotate keys on a schedule (monthly minimum) and immediately after any suspected leak</li>
                 <li>Use separate API keys per environment (dev, staging, prod)</li>
                 <li>Give each key the minimum permissions needed for its job</li>
@@ -682,8 +682,8 @@ budgetTracker.recordUsage(
               data that your agent processes. It can hijack an agent's behavior just like
               SQL injection hijacks a database query.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// Dangerous: user input goes directly into system context
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Dangerous: user input goes directly into system context
 const response = await anthropic.messages.create({
   system: \`You are a helpful assistant for \${company.name}.\`,
   messages: [{
@@ -715,7 +715,7 @@ If the user asks you to do anything outside your scope, politely decline.\`,
 function sanitizeInput(input: string): string {
   // Remove XML-like tags that could break your prompt structure
   return input.replace(/<[^>]*>/g, "").slice(0, 2000);
-}`}</pre>
+}`}</code></pre>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -729,7 +729,7 @@ function sanitizeInput(input: string): string {
             <div className="bg-blue-50 border-l-4 border-blue-600 p-6">
               <p className="font-semibold text-gray-900 mb-2">From The Website&apos;s March build:</p>
               <p className="text-gray-700 text-sm">
-                During the March build on Agentix, worker agents had scoped GitHub App
+                During the March build on <a href="https://agentix.cloud" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Agentix</a>, worker agents had scoped GitHub App
                 tokens — they could open PRs and post comments, but only on the specific
                 repo they were working on. The CEO agent had a broader token for creating
                 tasks, but workers couldn&apos;t create new workers or modify the task
@@ -754,8 +754,8 @@ function sanitizeInput(input: string): string {
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Handling Provider Rate Limits
             </h3>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/rate-limiter.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/rate-limiter.ts
 // Token bucket algorithm — smooth out bursts
 export class TokenBucket {
   private tokens: number;
@@ -808,7 +808,7 @@ const githubLimiter = new TokenBucket(100, 1.4);
 async function callGitHub(fn: () => Promise<unknown>) {
   await githubLimiter.consume(1);
   return fn();
-}`}</pre>
+}`}</code></pre>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -816,11 +816,11 @@ async function callGitHub(fn: () => Promise<unknown>) {
             </h3>
             <p className="text-gray-700 leading-relaxed mb-4">
               When an API returns a 429, it often includes a{" "}
-              <code className="bg-gray-100 px-1 rounded text-sm">Retry-After</code> header
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">Retry-After</code> header
               telling you exactly when to try again. Use it.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`async function callWithRespectfulRetry<T>(fn: () => Promise<T>): Promise<T> {
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`async function callWithRespectfulRetry<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
   } catch (error) {
@@ -837,7 +837,7 @@ async function callGitHub(fn: () => Promise<unknown>) {
     }
     throw error;
   }
-}`}</pre>
+}`}</code></pre>
             </div>
           </div>
 
@@ -861,8 +861,8 @@ async function callGitHub(fn: () => Promise<unknown>) {
               prevents a cascade where a failing downstream service causes your whole
               agent to spin in an error loop.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/circuit-breaker.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/circuit-breaker.ts
 type CircuitState = "closed" | "open" | "half-open";
 
 export class CircuitBreaker {
@@ -912,7 +912,7 @@ export class CircuitBreaker {
 
 // One circuit breaker per dependency
 const githubCircuit = new CircuitBreaker(5, 60000);
-const result = await githubCircuit.call(() => createGitHubPR(options));`}</pre>
+const result = await githubCircuit.call(() => createGitHubPR(options));`}</code></pre>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -922,8 +922,8 @@ const result = await githubCircuit.call(() => createGitHubPR(options));`}</pre>
               Partial results are almost always better than no results. Design agents
               to return what they completed, not to fail entirely when one step breaks.
             </p>
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// Instead of: all or nothing
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Instead of: all or nothing
 async function processAllTasks(tasks: Task[]): Promise<Result[]> {
   return Promise.all(tasks.map(processTask)); // One failure = total failure
 }
@@ -955,7 +955,7 @@ async function processAllTasksGracefully(tasks: Task[]): Promise<{
   }
 
   return { results, errors };
-}`}</pre>
+}`}</code></pre>
             </div>
 
             <div className="bg-blue-50 border-l-4 border-blue-600 p-6">
@@ -987,8 +987,8 @@ async function processAllTasksGracefully(tasks: Task[]): Promise<{
               in one place.
             </p>
 
-            <div className="bg-neutral-900 rounded-lg p-5 mb-6">
-              <pre className="text-sm text-green-400 overflow-x-auto">{`// lib/agent-runner.ts
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// lib/agent-runner.ts
 import Anthropic from "@anthropic-ai/sdk";
 import { withRetry } from "./retry";
 import { logger } from "./logger";
@@ -1079,7 +1079,7 @@ const result = await runAgent({
   role: "content-writer",
   systemPrompt: "You are a technical writer...",
   userMessage: "Write a blog post about...",
-});`}</pre>
+});`}</code></pre>
             </div>
 
             <div className="bg-green-50 border border-green-200 rounded-lg p-6">

--- a/app/course/module-8/page.tsx
+++ b/app/course/module-8/page.tsx
@@ -80,9 +80,9 @@ export default function Module8() {
             <div className="bg-yellow-50 border-l-4 border-yellow-500 p-5 mb-6">
               <p className="font-semibold text-gray-900 mb-1">The Website&apos;s production stack</p>
               <p className="text-sm text-gray-700">
-                Next.js on Vercel + Turso (SQLite). The original agent pipeline
-                ran on GitHub Actions; today orchestration runs through Orca driving
-                Claude Code workers. Infrastructure runs roughly $20–40 a month at
+                <a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Next.js</a> on <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> + <a href="https://turso.tech" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Turso</a> (SQLite). The original agent pipeline
+                ran on GitHub Actions; today orchestration runs through <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a> driving
+                <a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a> workers. Infrastructure runs roughly $20–40 a month at
                 current traffic — much of it inside free tiers — with plenty of
                 headroom to grow.
               </p>
@@ -188,8 +188,8 @@ export default function Module8() {
               2. Environment Management
             </h2>
             <p className="text-gray-700 leading-relaxed mb-4">
-              AI agents use a lot of secrets: API keys for Claude, GitHub, Stripe,
-              Resend. Mismanaging these is one of the most common production failures I see.
+              AI agents use a lot of secrets: API keys for Claude, GitHub, <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a>,
+              <a href="https://resend.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Resend</a>. Mismanaging these is one of the most common production failures I see.
               Here&apos;s the system that works.
             </p>
 
@@ -235,7 +235,7 @@ export default function Module8() {
             <p className="text-gray-700 leading-relaxed mb-3">
               Never commit secrets to git. The Website uses this pattern:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`# .env.local (never committed, in .gitignore)
 ANTHROPIC_API_KEY=sk-ant-...
 TURSO_DATABASE_URL=libsql://...
@@ -255,7 +255,7 @@ GITHUB_PRIVATE_KEY=
 STRIPE_SECRET_KEY=
 RESEND_API_KEY=
 NEXTAUTH_SECRET=`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Validating Environment Variables at Startup
@@ -264,7 +264,7 @@ NEXTAUTH_SECRET=`}
               Silent failures from missing env vars are the worst. Add a validation check
               that runs at startup and fails loudly:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// lib/env.ts
 const required = [
   "ANTHROPIC_API_KEY",
@@ -289,7 +289,7 @@ export const env = {
   tursoToken: process.env.TURSO_AUTH_TOKEN!,
   nextAuthSecret: process.env.NEXTAUTH_SECRET!,
 } as const;`}
-            </pre>
+            </code></pre></div>
 
             <div className="bg-red-50 border-l-4 border-red-500 p-5">
               <p className="font-semibold text-gray-900 mb-1">The failure mode this prevents</p>
@@ -327,7 +327,7 @@ export const env = {
               <p className="mt-2 text-gray-500 text-xs">Writes go to primary → replicate out to replicas asynchronously (typically fast, but not instant — reads from replicas can briefly lag writes)</p>
             </div>
 
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// lib/db.ts — connect to nearest replica automatically
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
@@ -345,7 +345,7 @@ export const primaryClient = createClient({
   authToken: process.env.TURSO_AUTH_TOKEN!,
 });
 export const primaryDb = drizzle(primaryClient);`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Read vs. Write Routing Pattern
@@ -354,7 +354,7 @@ export const primaryDb = drizzle(primaryClient);`}
               The key insight: most agent operations are reads (checking cache, loading
               context, fetching issues). Route reads to replicas, writes to primary:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-6">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// Read from nearest replica (fast, globally distributed)
 const issues = await db
   .select()
@@ -369,7 +369,7 @@ await primaryDb
     target: issueCache.id,
     set: { title, status, votes },
   });`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Database Connection Pooling
@@ -379,7 +379,7 @@ await primaryDb
               connection by default. At scale this exhausts connection limits fast. Fix it
               with a module-level singleton:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// lib/db.ts — module-level singleton (reused across warm invocations)
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
@@ -397,7 +397,7 @@ export function getDb() {
   }
   return _db;
 }`}
-            </pre>
+            </code></pre></div>
           </div>
 
           {/* Section 4: Monitoring */}
@@ -442,7 +442,7 @@ export function getDb() {
               unhandled error, Sentry captures the full context: request headers, user
               session, recent breadcrumbs. Setup takes 5 minutes:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// sentry.server.config.ts
 import * as Sentry from "@sentry/nextjs";
 
@@ -472,7 +472,7 @@ export async function runAgentTask(taskId: string, fn: () => Promise<void>) {
     }
   });
 }`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               What to Monitor for AI Agents
@@ -539,7 +539,7 @@ export async function runAgentTask(taskId: string, fn: () => Promise<void>) {
               context blocks. If your agent has a large system prompt that doesn&apos;t change,
               cache it—saves 90% on input token cost for cached portions:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`import Anthropic from "@anthropic-ai/sdk";
 
 const client = new Anthropic();
@@ -562,7 +562,7 @@ const response = await client.messages.create({
 
 // Subsequent calls with the same cached block cost ~10x less
 // Cache persists for ~5 minutes by default`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Strategy 2: Model Routing
@@ -571,7 +571,7 @@ const response = await client.messages.create({
               Not every task needs the most powerful (expensive) model. Route tasks to the
               cheapest model that can handle them:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// lib/model-router.ts
 type TaskType = "classify" | "summarize" | "code" | "reason";
 
@@ -597,7 +597,7 @@ const response = await client.messages.create({
   max_tokens: 100,
   messages: [{ role: "user", content: "Classify this issue: is it a bug or feature?" }],
 });`}
-            </pre>
+            </code></pre></div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
               Strategy 3: Response Caching
@@ -607,7 +607,7 @@ const response = await client.messages.create({
               Issue classification, sentiment analysis, and label suggestions are all good
               candidates:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// lib/llm-cache.ts
 import { db } from "./db";
 import { llmCache } from "./schema";
@@ -650,7 +650,7 @@ const label = await cachedCompletion(
   \`Classify issue: "\${issue.title}"\`,
   () => classifyWithClaude(issue)
 );`}
-            </pre>
+            </code></pre></div>
           </div>
 
           {/* Section 6: Rate Limiting */}
@@ -662,7 +662,7 @@ const label = await cachedCompletion(
               Without rate limiting, a single bad actor or runaway script can exhaust your
               API quotas in minutes. The classic self-inflicted version: a test loop with
               no delay hammering your own{" "}
-              <code className="bg-gray-100 px-1 rounded text-sm">/api/requests</code>
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">/api/requests</code>
               endpoint hundreds of times in seconds. Agents write loops like that
               constantly — assume it will happen.
             </p>
@@ -688,7 +688,7 @@ const label = await cachedCompletion(
               Upstash Redis is serverless-friendly (HTTP-based, no connection pooling
               headaches) and gives every instance the same view of the counter:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 
@@ -718,7 +718,7 @@ export async function POST(req: Request) {
 
   // ... handle request
 }`}
-            </pre>
+            </code></pre></div>
           </div>
 
           {/* Section 7: Safe Rollouts */}
@@ -741,7 +741,7 @@ export async function POST(req: Request) {
               runnable forever. &quot;Rollback&quot; is just repointing production traffic at
               a previous deployment, which takes seconds and requires no rebuild:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`# List recent deployments
 vercel ls
 
@@ -749,7 +749,7 @@ vercel ls
 vercel rollback <deployment-url>
 
 # Or in the dashboard: Deployments → ⋯ → "Instant Rollback"`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4">
               The catch: rollback only reverts <em>code</em>. It does not undo database
               migrations, cache contents, or env-var changes. Which is why the next two
@@ -765,7 +765,7 @@ vercel rollback <deployment-url>
               previous version of the code can&apos;t live with. Split breaking changes into
               three deploys:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`-- Goal: rename tasks.assignee → tasks.worker_id
 
 -- Deploy 1 (EXPAND): add the new column; old code ignores it
@@ -777,7 +777,7 @@ UPDATE tasks SET worker_id = assignee WHERE worker_id IS NULL;
 
 -- Deploy 3 (CONTRACT): once nothing reads assignee, drop it
 ALTER TABLE tasks DROP COLUMN assignee;`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4">
               At every step, both the current and previous deploy work against the current
               schema—so instant rollback stays safe. Slower than one big migration, but a
@@ -824,7 +824,7 @@ ALTER TABLE tasks DROP COLUMN assignee;`}
                       Fastest. Lives in the Node.js process. Lost on restart. Use for
                       hot data that changes rarely: config, feature flags, model outputs.
                     </p>
-                    <pre className="bg-gray-50 p-3 rounded text-xs font-mono text-gray-700">{`const cache = new Map<string, { value: unknown; expiresAt: number }>();
+                    <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`const cache = new Map<string, { value: unknown; expiresAt: number }>();
 
 export function memCache<T>(key: string, ttlMs: number, fn: () => T): T {
   const entry = cache.get(key);
@@ -832,7 +832,7 @@ export function memCache<T>(key: string, ttlMs: number, fn: () => T): T {
   const value = fn();
   cache.set(key, { value, expiresAt: Date.now() + ttlMs });
   return value;
-}`}</pre>
+}`}</code></pre></div>
                   </div>
                 </div>
               </div>
@@ -846,7 +846,7 @@ export function memCache<T>(key: string, ttlMs: number, fn: () => T): T {
                       Medium speed. Persistent across restarts. The Website stores GitHub
                       issues here. Shared across all instances.
                     </p>
-                    <pre className="bg-gray-50 p-3 rounded text-xs font-mono text-gray-700">{`// Store expensive API results in Turso
+                    <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Store expensive API results in Turso
 await db.insert(issueCache).values({
   id: issue.number,
   title: issue.title,
@@ -854,7 +854,7 @@ await db.insert(issueCache).values({
   votes: issue.reactions["+1"],
   cachedAt: new Date(),
   expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5 min TTL
-}).onConflictDoUpdate({ target: issueCache.id, set: { ... } });`}</pre>
+}).onConflictDoUpdate({ target: issueCache.id, set: { ... } });`}</code></pre></div>
                   </div>
                 </div>
               </div>
@@ -868,7 +868,7 @@ await db.insert(issueCache).values({
                       Fastest at scale. Responses cached at the CDN edge—Vercel does this
                       automatically for static routes. Add cache headers for dynamic routes.
                     </p>
-                    <pre className="bg-gray-50 p-3 rounded text-xs font-mono text-gray-700">{`// Cache API response at CDN for 60 seconds
+                    <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// Cache API response at CDN for 60 seconds
 return Response.json(data, {
   headers: {
     "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
@@ -876,7 +876,7 @@ return Response.json(data, {
 });
 
 // Or use Next.js route config:
-export const revalidate = 60; // revalidate every 60 seconds`}</pre>
+export const revalidate = 60; // revalidate every 60 seconds`}</code></pre></div>
                   </div>
                 </div>
               </div>
@@ -889,7 +889,7 @@ export const revalidate = 60; // revalidate every 60 seconds`}</pre>
               The classic problem: when data changes, cached copies become stale. For The
               Website&apos;s issue cache, I use a simple TTL + event-based invalidation:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// When a user votes, immediately invalidate the specific issue cache
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   const issueId = Number(params.id);
@@ -910,7 +910,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   return Response.json({ success: true });
 }`}
-            </pre>
+            </code></pre></div>
           </div>
 
           {/* Section 9: Horizontal Scaling */}
@@ -934,24 +934,24 @@ export async function POST(req: Request, { params }: { params: { id: string } })
             <div className="grid md:grid-cols-2 gap-4 mb-6">
               <div className="border border-red-200 rounded-lg p-4 bg-red-50">
                 <p className="font-semibold text-red-700 text-sm mb-2">Stateful (hard to scale)</p>
-                <pre className="text-xs font-mono text-red-800">{`// State lives in memory
+                <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// State lives in memory
 let taskQueue: Task[] = [];
 let currentTask: Task | null = null;
 
 // Instance A and Instance B have
 // different queues → race conditions,
-// duplicate work, inconsistency`}</pre>
+// duplicate work, inconsistency`}</code></pre></div>
               </div>
               <div className="border border-green-200 rounded-lg p-4 bg-green-50">
                 <p className="font-semibold text-green-700 text-sm mb-2">Stateless (scales horizontally)</p>
-                <pre className="text-xs font-mono text-green-800">{`// State lives in database
+                <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>{`// State lives in database
 const task = await db
   .update(tasks)
   .set({ status: "in_progress", workerId: MY_ID })
   .where(eq(tasks.status, "pending"))
   .returning()
   .get();
-// Atomic claim — works across N instances`}</pre>
+// Atomic claim — works across N instances`}</code></pre></div>
               </div>
             </div>
 
@@ -962,7 +962,7 @@ const task = await db
               For background agents that process tasks, use a database-backed work queue.
               Multiple worker instances poll the queue; atomic claims prevent duplicates:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800 mb-4">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`// work-queue.ts — the pattern Agentix implements as a hosted service
 import { db } from "./db";
 import { tasks } from "./schema";
@@ -1018,11 +1018,11 @@ async function workerLoop() {
     }
   }
 }`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4 text-sm">
               One caveat on the &quot;atomic claim&quot;: with Turso, all writes (including
-              this claim <code className="bg-gray-100 px-1 rounded">UPDATE</code>) go to the
-              primary, and as written the <code className="bg-gray-100 px-1 rounded">WHERE</code>
+              this claim <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">UPDATE</code>) go to the
+              primary, and as written the <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">WHERE</code>
               {" "}matches <em>every</em> pending row—so verify your driver gives you
               LIMIT-1 claim semantics (or add a subquery selecting a single task id) and
               test the pattern under real concurrency before trusting it.
@@ -1036,7 +1036,7 @@ async function workerLoop() {
               Each issue triggered a separate job, so multiple issues could be processed
               concurrently:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm font-mono text-gray-800">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`# .github/workflows/agent.yml (simplified)
 on:
   issues:
@@ -1055,7 +1055,7 @@ jobs:
       - run: |
           # Each job is an isolated worker — no shared state
           node scripts/process-issue.js \${{ github.event.issue.number }}`}
-            </pre>
+            </code></pre></div>
 
             <div className="bg-blue-50 border-l-4 border-blue-500 p-5 mt-6">
               <p className="font-semibold text-gray-900 mb-1">How The Website currently scales</p>
@@ -1143,9 +1143,9 @@ jobs:
                     <p className="font-semibold text-gray-900 mb-1">Deploy your agent to Vercel</p>
                     <p className="text-sm text-gray-600">
                       Take the agent you built in Module 2 and deploy it. Add a
-                      <code className="bg-gray-100 px-1 rounded mx-1">/api/run</code>
+                      <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm mx-1">/api/run</code>
                       endpoint that accepts a task via POST and runs the agent. Verify it
-                      works via <code className="bg-gray-100 px-1 rounded">curl</code> after deploy.
+                      works via <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">curl</code> after deploy.
                     </p>
                   </div>
                 </div>
@@ -1157,9 +1157,9 @@ jobs:
                   <div>
                     <p className="font-semibold text-gray-900 mb-1">Add environment validation</p>
                     <p className="text-sm text-gray-600">
-                      Implement the <code className="bg-gray-100 px-1 rounded">validateEnv()</code> pattern
+                      Implement the <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">validateEnv()</code> pattern
                       from Section 2. Call it at the start of your
-                      <code className="bg-gray-100 px-1 rounded mx-1">instrumentation.ts</code>
+                      <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm mx-1">instrumentation.ts</code>
                       (Next.js startup hook) so a missing secret fails the deploy rather
                       than silently breaking in production.
                     </p>
@@ -1173,7 +1173,7 @@ jobs:
                   <div>
                     <p className="font-semibold text-gray-900 mb-1">Wire your logging into the platform</p>
                     <p className="text-sm text-gray-600">
-                      Take the <code className="bg-gray-100 px-1 rounded">Logger</code> class you
+                      Take the <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">Logger</code> class you
                       built in Module 7 and deploy it: confirm it emits one JSON object per
                       line in production, log every task start, completion, failure, tokens
                       used, and duration, then set up a Vercel log drain and query the drained
@@ -1191,7 +1191,7 @@ jobs:
                     <p className="text-sm text-gray-600">
                       Protect your agent&apos;s public endpoint with rate limiting. Allow 10
                       requests per minute per IP. Return a proper 429 response with
-                      <code className="bg-gray-100 px-1 rounded mx-1">Retry-After</code>
+                      <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm mx-1">Retry-After</code>
                       header. Test it by writing a quick script that fires 15 requests
                       rapidly and confirm it gets rate limited.
                     </p>

--- a/app/course/module-9/page.tsx
+++ b/app/course/module-9/page.tsx
@@ -257,18 +257,18 @@ export default function Module9() {
             <p className="text-gray-700 leading-relaxed mb-4">
               The fastest path to a working AI agent product:
             </p>
-            <div className="bg-gray-900 rounded-lg p-6 mb-6 font-mono text-sm">
-              <p className="text-green-400 mb-2"># Week 1: Core loop working</p>
-              <p className="text-white mb-1">Input → Agent → Output → Human review</p>
-              <p className="text-gray-500 mb-4">Just get the agent to produce something useful. Manually check everything.</p>
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto font-mono text-sm">
+              <p className="text-neutral-400 mb-2"># Week 1: Core loop working</p>
+              <p className="text-neutral-100 mb-1">Input → Agent → Output → Human review</p>
+              <p className="text-neutral-500 mb-4">Just get the agent to produce something useful. Manually check everything.</p>
 
-              <p className="text-green-400 mb-2"># Week 2: Automate the review</p>
-              <p className="text-white mb-1">Input → Agent → Validation → Output</p>
-              <p className="text-gray-500 mb-4">Add structured output validation. Catch failures before they reach customers.</p>
+              <p className="text-neutral-400 mb-2"># Week 2: Automate the review</p>
+              <p className="text-neutral-100 mb-1">Input → Agent → Validation → Output</p>
+              <p className="text-neutral-500 mb-4">Add structured output validation. Catch failures before they reach customers.</p>
 
-              <p className="text-green-400 mb-2"># Week 3: Add the business layer</p>
-              <p className="text-white mb-1">Auth + Payments + Rate limiting</p>
-              <p className="text-gray-500">Now you can charge for it and not get abused.</p>
+              <p className="text-neutral-400 mb-2"># Week 3: Add the business layer</p>
+              <p className="text-neutral-100 mb-1">Auth + Payments + Rate limiting</p>
+              <p className="text-neutral-500">Now you can charge for it and not get abused.</p>
             </div>
 
             <h3 className="text-xl font-semibold text-gray-900 mb-3">
@@ -497,10 +497,10 @@ export default function Module9() {
                   <p className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-2">Key Partners</p>
                   <ul className="text-xs text-gray-700 space-y-1">
                     <li>• Anthropic (Claude API)</li>
-                    <li>• Vercel (hosting)</li>
+                    <li>• <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> (hosting)</li>
                     <li>• GitHub (platform)</li>
-                    <li>• Turso (database)</li>
-                    <li>• Stripe (payments)</li>
+                    <li>• <a href="https://turso.tech" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Turso</a> (database)</li>
+                    <li>• <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a> (payments)</li>
                   </ul>
                 </div>
                 <div className="p-4 bg-white col-span-1">
@@ -585,7 +585,7 @@ export default function Module9() {
                         is I don&apos;t have a per-task number from logs, so I
                         won&apos;t publish one (see Module 10 on exactly this
                         mistake)</li>
-                        <li>• GitHub Actions, Resend email: fractions of a cent
+                        <li>• GitHub Actions, <a href="https://resend.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Resend</a> email: fractions of a cent
                         per run/send</li>
                       </ul>
                     </div>
@@ -615,14 +615,14 @@ export default function Module9() {
               <li><strong>Caching and batching are P&L decisions, not just engineering optimizations.</strong> A 40% cost reduction from caching is a 40% margin improvement.</li>
               <li><strong>Model selection is a pricing lever.</strong> Opus costs 5x what Haiku does per token ($5 vs $1/MTok input) — a task that costs $0.50 with Opus runs ~$0.10 with Haiku. If quality is acceptable, that&apos;s a 5x cost reduction on your biggest variable expense.</li>
             </ul>
-            <div className="bg-gray-900 rounded-lg p-6 mb-6 font-mono text-sm">
-              <p className="text-green-400 mb-2"># Unit economics sanity check (illustrative numbers)</p>
-              <p className="text-white">revenue_per_task = 1.00  <span className="text-gray-400"># hypothetical: $100 product / 100 tasks included</span></p>
-              <p className="text-white">cost_per_task = 0.12    <span className="text-gray-400"># Claude API + infra</span></p>
-              <p className="text-white">gross_margin = (revenue_per_task - cost_per_task) / revenue_per_task</p>
-              <p className="text-green-400 mt-2"># gross_margin = 0.88 = 88% — healthy</p>
-              <p className="text-white mt-3">monthly_tasks_to_break_even = fixed_costs / (revenue_per_task - cost_per_task)</p>
-              <p className="text-green-400"># ~$30 fixed / $0.88 contribution = ~34 tasks/month</p>
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto font-mono text-sm">
+              <p className="text-neutral-400 mb-2"># Unit economics sanity check (illustrative numbers)</p>
+              <p className="text-neutral-100">revenue_per_task = 1.00  <span className="text-neutral-500"># hypothetical: $100 product / 100 tasks included</span></p>
+              <p className="text-neutral-100">cost_per_task = 0.12    <span className="text-neutral-500"># Claude API + infra</span></p>
+              <p className="text-neutral-100">gross_margin = (revenue_per_task - cost_per_task) / revenue_per_task</p>
+              <p className="text-neutral-400 mt-2"># gross_margin = 0.88 = 88% — healthy</p>
+              <p className="text-neutral-100 mt-3">monthly_tasks_to_break_even = fixed_costs / (revenue_per_task - cost_per_task)</p>
+              <p className="text-neutral-400"># ~$30 fixed / $0.88 contribution = ~34 tasks/month</p>
             </div>
           </div>
 
@@ -851,22 +851,22 @@ export default function Module9() {
               Before scaling acquisition, you must understand CAC (customer acquisition
               cost) and LTV (lifetime value). For a developer tool:
             </p>
-            <div className="bg-gray-900 rounded-lg p-6 mb-6 font-mono text-sm">
-              <p className="text-gray-400 mb-3"># Healthy: LTV &gt; 3x CAC</p>
-              <p className="text-white">LTV = avg_revenue_per_customer × avg_customer_lifetime</p>
-              <p className="text-white">CAC = total_acquisition_spend / new_customers_acquired</p>
-              <p className="text-white mt-3">
-                <span className="text-green-400"># Example: $100 one-time course</span>
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto font-mono text-sm">
+              <p className="text-neutral-500 mb-3"># Healthy: LTV &gt; 3x CAC</p>
+              <p className="text-neutral-100">LTV = avg_revenue_per_customer × avg_customer_lifetime</p>
+              <p className="text-neutral-100">CAC = total_acquisition_spend / new_customers_acquired</p>
+              <p className="text-neutral-100 mt-3">
+                <span className="text-neutral-400"># Example: $100 one-time course</span>
               </p>
-              <p className="text-white">LTV = $100 × 1 = $100  <span className="text-gray-400"># one-time; no expansion</span></p>
-              <p className="text-white">CAC = $5  <span className="text-gray-400"># content-driven; near zero</span></p>
-              <p className="text-white">LTV/CAC = 20  <span className="text-gray-400"># excellent</span></p>
-              <p className="text-white mt-3">
-                <span className="text-green-400"># Example: $50/month subscription, 12mo avg lifetime</span>
+              <p className="text-neutral-100">LTV = $100 × 1 = $100  <span className="text-neutral-500"># one-time; no expansion</span></p>
+              <p className="text-neutral-100">CAC = $5  <span className="text-neutral-500"># content-driven; near zero</span></p>
+              <p className="text-neutral-100">LTV/CAC = 20  <span className="text-neutral-500"># excellent</span></p>
+              <p className="text-neutral-100 mt-3">
+                <span className="text-neutral-400"># Example: $50/month subscription, 12mo avg lifetime</span>
               </p>
-              <p className="text-white">LTV = $50 × 12 = $600</p>
-              <p className="text-white">CAC = $50  <span className="text-gray-400"># some paid or outbound</span></p>
-              <p className="text-white">LTV/CAC = 12  <span className="text-gray-400"># strong</span></p>
+              <p className="text-neutral-100">LTV = $50 × 12 = $600</p>
+              <p className="text-neutral-100">CAC = $50  <span className="text-neutral-500"># some paid or outbound</span></p>
+              <p className="text-neutral-100">LTV/CAC = 12  <span className="text-neutral-500"># strong</span></p>
             </div>
           </div>
 


### PR DESCRIPTION
Engineer (task_6532306a3d1c). Fixes the light-mode code-readability issue Nalin flagged + adds verified third-party tool links.

- Every multi-line code sample in modules 6-10 standardized to the dark-container spec (bg-neutral-900 + text-neutral-100), readable in both themes. **Module 8 was the real bug** — 20 code blocks with no dark container. Inline code normalized to a light-mode-readable chip.
- 21 first-mention tool links added (Orca, Agentix, Claude Code, Anthropic SDK, OpenClaw, Turso, Vercel, Next.js, Drizzle, Resend, Stripe). **CEO pre-verified all 11 distinct URLs return 200** (no dead links).
- No facts/metrics/metadata/CTAs changed; build green, tests at baseline.

Routing to content-reviewer (public course content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)