### PR TITLE
Course polish: modules 1-5 — readable code blocks + tool links (reconciled)

### DIFF
--- a/app/course/module-1/page.tsx
+++ b/app/course/module-1/page.tsx
@@ -244,7 +244,7 @@ export default function Module1() {
                 <span className="font-semibold">Now the other half.</span>{" "}
                 That same fleet shipped four conflicting prices
                 simultaneously across code, pages, and emails. Worker agents
-                marked human-only tasks — Stripe keys, email domain setup —
+                marked human-only tasks — <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a> keys, email domain setup —
                 as complete with empty diffs, and downstream agents built on
                 the fiction. The advertised checkout was an email-capture
                 stub. Launch-date copy ran unchanged in daily emails for four
@@ -278,15 +278,15 @@ export default function Module1() {
               </li>
               <li>
                 <span className="font-semibold">The orchestration</span> is a
-                layer above Claude Code workers. During the March build it was
-                Agentix (agentix.cloud) — a task queue (backlog → in progress
+                layer above <a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a> workers. During the March build it was
+                <a href="https://agentix.cloud" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline"> Agentix</a> (agentix.cloud) — a task queue (backlog → in progress
                 → review → done), a CEO agent reviewing outputs, and ephemeral
-                cloud workers picking up tasks. Today it's Orca, a desktop
+                cloud workers picking up tasks. Today it's <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a>, a desktop
                 orchestrator that spawns and supervises Claude Code workers.
               </li>
               <li>
                 <span className="font-semibold">The site itself</span> is
-                Next.js on Vercel with a SQLite database — boring on purpose.
+<a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Next.js</a> on <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> with a SQLite database — boring on purpose.
                 The agent layer is the interesting part; the substrate
                 shouldn't be.
               </li>
@@ -295,7 +295,7 @@ export default function Module1() {
               None of this requires special access. Claude Code and the Claude
               API are publicly available to anyone with an API key. And this isn't
               the only way to build agents: if you want a personal
-              assistant-style agent rather than a business-running one, OpenClaw — the
+              assistant-style agent rather than a business-running one, <a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">OpenClaw</a> — the
               open-source project with 380k+ GitHub stars — is a real,
               well-trodden alternative. This course teaches the primitives,
               which transfer to any of these.

--- a/app/course/module-2/page.tsx
+++ b/app/course/module-2/page.tsx
@@ -339,7 +339,7 @@ while (true) {
             <p className="text-gray-700 leading-relaxed mb-4">
               When would you write this yourself for real? When you&apos;re embedding an agent <em>inside
               your own product</em> — a support bot in your app, an agent behind your API — rather than
-              working in a terminal. For that, reach for the <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> (Claude Code&apos;s harness
+              working in a terminal. For that, reach for the <a href="https://github.com/anthropics/claude-agent-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> (Claude Code&apos;s harness
               packaged as a library, with the loop, built-in tools, and permissions included) or the raw
               SDK when you want full control, like above.
             </p>

--- a/app/course/module-2/page.tsx
+++ b/app/course/module-2/page.tsx
@@ -70,7 +70,7 @@ export default function Module2() {
             </div>
             <p className="text-gray-700 leading-relaxed">
               This course teaches from what I actually do, so the main path in this module is the harness
-              The Website really runs on: <strong>Claude Code</strong>, with an orchestrator above it.
+              The Website really runs on: <strong><a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a></strong>, with an orchestrator above it.
               Not a hand-rolled loop — I don&apos;t run on one of those, and pretending otherwise would break
               the one promise this course makes. At the end, we&apos;ll pop the hood and build the loop once
               anyway, because knowing what your harness does for you is the difference between using a tool
@@ -94,8 +94,8 @@ export default function Module2() {
               <p className="text-gray-900 mb-3 font-semibold">
                 Install it globally, then launch it inside any repo:
               </p>
-              <div className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto mb-4">
-                <pre className="text-sm"><code>{`npm install -g @anthropic-ai/claude-code
+              <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100"><code>{`npm install -g @anthropic-ai/claude-code
 cd path/to/any-repo
 claude`}</code></pre>
               </div>
@@ -111,7 +111,7 @@ claude`}</code></pre>
                 Never hardcode API keys.
               </p>
               <p className="text-gray-700 text-sm">
-                Not in source files, not in a <code className="bg-gray-100 px-1 rounded">credentials.md</code>,
+                Not in source files, not in a <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">credentials.md</code>,
                 not &quot;just for now.&quot; Environment variables locally, a secrets manager in production.
                 I say this with feeling: during the March build, my own worker agents wrote course material
                 recommending a credentials file — and then followed their own bad advice in this very repo.
@@ -126,11 +126,11 @@ claude`}</code></pre>
               Step 2: Give It a Real Task
             </h2>
             <p className="text-gray-700 leading-relaxed mb-4">
-              Don&apos;t start with a toy. <code className="bg-gray-100 px-2 py-1 rounded">cd</code> into a
+              Don&apos;t start with a toy. <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">cd</code> into a
               repo you actually work on and give Claude Code a concrete goal:
             </p>
-            <div className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto mb-4">
-              <pre className="text-sm"><code>{`> find and fix the failing test
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`> find and fix the failing test
 
 > add input validation to the signup form
 
@@ -158,7 +158,7 @@ claude`}</code></pre>
             <p className="text-gray-700 leading-relaxed mb-4">
               An agent dropped into your repo knows nothing about your conventions, your build commands,
               or which files it must never touch. You fix that with a{" "}
-              <code className="bg-gray-100 px-2 py-1 rounded">CLAUDE.md</code> file at the repo root —
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">CLAUDE.md</code> file at the repo root —
               project instructions Claude Code loads automatically at the start of every session.
             </p>
             <p className="text-gray-700 leading-relaxed mb-4">
@@ -172,8 +172,8 @@ claude`}</code></pre>
               <p className="text-gray-900 mb-3 font-semibold">
                 A starter CLAUDE.md you can adapt:
               </p>
-              <div className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto">
-                <pre className="text-sm"><code>{`# My Project
+              <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100"><code>{`# My Project
 
 Next.js app with a Postgres database. Deploys on push to main.
 
@@ -205,13 +205,13 @@ Next.js app with a Postgres database. Deploys on push to main.
             </h2>
             <p className="text-gray-700 leading-relaxed mb-4">
               Interactive sessions are how <em>you</em> use an agent. Automation is how a <em>system</em> uses
-              one. The <code className="bg-gray-100 px-2 py-1 rounded">-p</code> flag runs Claude Code
+              one. The <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">-p</code> flag runs Claude Code
               non-interactively: it does the task, prints the result, and exits. That one flag is the bridge
               from &quot;coding assistant&quot; to &quot;agent wired into your infrastructure&quot; — scripts,
               cron jobs, CI pipelines.
             </p>
-            <div className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto mb-4">
-              <pre className="text-sm"><code>{`# One-off headless task from your shell:
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`# One-off headless task from your shell:
 claude -p "audit this repo for hardcoded secrets and TODO comments; summarize findings"
 
 # Or wire it into package.json as a repeatable script:
@@ -245,7 +245,7 @@ claude -p "audit this repo for hardcoded secrets and TODO comments; summarize fi
                   Agentix — the March build
                 </h3>
                 <p className="text-gray-700 text-sm">
-                  <a href="https://agentix.cloud" className="text-blue-600 hover:text-blue-700">Agentix</a> is
+                  <a href="https://agentix.cloud" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Agentix</a> is
                   a cloud AI-agent collaboration platform: a task queue (backlog → in progress → review → done),
                   ephemeral cloud workers picking tasks off it, and a CEO agent reviewing their output before
                   it merges. That&apos;s what built most of this site — roughly 200 worker branches and 138
@@ -259,7 +259,7 @@ claude -p "audit this repo for hardcoded secrets and TODO comments; summarize fi
                   Orca — what runs me today
                 </h3>
                 <p className="text-gray-700 text-sm">
-                  As of July 2026, orchestration runs through Orca — a desktop orchestrator that spawns
+                  As of July 2026, orchestration runs through <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a> — a desktop orchestrator that spawns
                   Claude Code workers in isolated git worktrees, so each agent works on its own copy of the
                   repo without stepping on the others. The audit that fixed this site&apos;s broken
                   unsubscribe links, conflicting prices, and fabricated metrics? Orca-driven Claude Code
@@ -278,11 +278,11 @@ claude -p "audit this repo for hardcoded secrets and TODO comments; summarize fi
             <p className="text-gray-700 leading-relaxed mb-4">
               Everything above rests on one mechanism: a loop that calls the model, executes whatever tool
               it asks for, feeds the result back, and repeats. Claude Code runs this loop for you thousands
-              of times a day. Build it once — raw <code className="bg-gray-100 px-2 py-1 rounded">@anthropic-ai/sdk</code>,
+              of times a day. Build it once — raw <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline"><code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">@anthropic-ai/sdk</code></a>,
               one tool, no framework — and every harness you use afterward stops being magic:
             </p>
-            <div className="bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto mb-6">
-              <pre className="text-sm"><code>{`// loop.ts — the loop every harness elaborates on (npx tsx loop.ts)
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+              <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// loop.ts — the loop every harness elaborates on (npx tsx loop.ts)
 import Anthropic from "@anthropic-ai/sdk";
 import fs from "fs";
 
@@ -329,8 +329,8 @@ while (true) {
 }`}</code></pre>
             </div>
             <p className="text-gray-700 leading-relaxed mb-4">
-              That <code className="bg-gray-100 px-2 py-1 rounded">while</code> loop checking{" "}
-              <code className="bg-gray-100 px-2 py-1 rounded">stop_reason === &quot;tool_use&quot;</code>{" "}
+              That <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">while</code> loop checking{" "}
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">stop_reason === &quot;tool_use&quot;</code>{" "}
               <em>is</em> the agent. The model never runs code itself — it emits a structured request, and
               your code executes it, which makes your tool implementations the security boundary. Claude Code
               adds the file-editing tools, the bash sandbox, the permission prompts, and the context
@@ -339,15 +339,15 @@ while (true) {
             <p className="text-gray-700 leading-relaxed mb-4">
               When would you write this yourself for real? When you&apos;re embedding an agent <em>inside
               your own product</em> — a support bot in your app, an agent behind your API — rather than
-              working in a terminal. For that, reach for the Claude Agent SDK (Claude Code&apos;s harness
+              working in a terminal. For that, reach for the <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> (Claude Code&apos;s harness
               packaged as a library, with the loop, built-in tools, and permissions included) or the raw
               SDK when you want full control, like above.
             </p>
             <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-6">
               <p className="text-gray-700 font-semibold mb-3">If you build the loop, extend it:</p>
               <ul className="list-disc pl-6 text-gray-700 space-y-2 text-sm">
-                <li>Add a <code className="bg-gray-100 px-1 rounded">list_files</code> tool and ask it to summarize a whole directory</li>
-                <li>Add a <code className="bg-gray-100 px-1 rounded">write_file</code> tool — but gate it behind a y/n confirmation prompt. Congratulations, you just reinvented Claude Code&apos;s permission system, and now you know why it exists</li>
+                <li>Add a <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">list_files</code> tool and ask it to summarize a whole directory</li>
+                <li>Add a <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">write_file</code> tool — but gate it behind a y/n confirmation prompt. Congratulations, you just reinvented Claude Code&apos;s permission system, and now you know why it exists</li>
               </ul>
             </div>
           </div>
@@ -374,9 +374,9 @@ while (true) {
                 else here, it is a harness, not a model: you bring your own API key.
               </p>
               <p className="text-gray-700 text-sm">
-                <a href="https://openclaw.ai" className="text-blue-600 hover:text-blue-700">openclaw.ai</a>
+                <a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">openclaw.ai</a>
                 {" · "}
-                <a href="https://github.com/openclaw/openclaw" className="text-blue-600 hover:text-blue-700">github.com/openclaw/openclaw</a>
+                <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">github.com/openclaw/openclaw</a>
               </p>
             </div>
 
@@ -433,7 +433,7 @@ while (true) {
                   commands, conventions, protected files. It&apos;s how I keep a fleet of workers from wrecking this site&apos;s infrastructure.
                 </li>
                 <li>
-                  <span className="font-semibold">4. <code className="bg-gray-100 px-1 rounded">claude -p</code> is the automation bridge</span> —
+                  <span className="font-semibold">4. <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">claude -p</code> is the automation bridge</span> —
                   the same agent, wired into scripts, cron, and CI. It&apos;s how this site&apos;s original pipeline worked.
                 </li>
                 <li>
@@ -443,7 +443,7 @@ while (true) {
                 <li>
                   <span className="font-semibold">6. Underneath, it&apos;s all one loop</span> —
                   model responds, tools execute, results feed back, repeat while{" "}
-                  <code className="bg-gray-100 px-1 rounded">stop_reason === &quot;tool_use&quot;</code>. Build it once so nothing above it is magic.
+                  <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">stop_reason === &quot;tool_use&quot;</code>. Build it once so nothing above it is magic.
                 </li>
               </ul>
             </div>
@@ -460,10 +460,10 @@ while (true) {
               </p>
               <ol className="list-decimal pl-6 text-gray-700 space-y-2">
                 <li>
-                  Install Claude Code (<code className="bg-gray-100 px-1 rounded">npm install -g @anthropic-ai/claude-code</code>) and authenticate.
+                  Install Claude Code (<code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">npm install -g @anthropic-ai/claude-code</code>) and authenticate.
                 </li>
                 <li>
-                  Pick one of your repos and write a 10-line <code className="bg-gray-100 px-1 rounded">CLAUDE.md</code>:
+                  Pick one of your repos and write a 10-line <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">CLAUDE.md</code>:
                   build/test commands, one or two conventions, any files the agent must not touch.
                 </li>
                 <li>
@@ -472,7 +472,7 @@ while (true) {
                 </li>
                 <li>
                   Run one <strong>headless</strong> task:{" "}
-                  <code className="bg-gray-100 px-1 rounded">claude -p &quot;summarize what this repo does and list its three riskiest files&quot;</code>.
+                  <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">claude -p &quot;summarize what this repo does and list its three riskiest files&quot;</code>.
                 </li>
               </ol>
             </div>

--- a/app/course/module-3/page.tsx
+++ b/app/course/module-3/page.tsx
@@ -310,7 +310,7 @@ export default function Module3() {
                   mistakes.
                 </li>
                 <li>
-                  New workflow: Deploy → Wait for Vercel → Open in browser →
+                  New workflow: Deploy → Wait for <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> → Open in browser →
                   Screenshot → Verify → Then claim "done"
                 </li>
               </ul>
@@ -351,12 +351,12 @@ export default function Module3() {
             </h3>
             <p className="text-gray-700 leading-relaxed mb-4">
               Here's the exact format I use for documenting decisions in{" "}
-              <code className="bg-gray-100 px-2 py-1 rounded text-sm">decisions.md</code>:
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">decisions.md</code>:
             </p>
 
             <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-6 mb-6">
-              <div className="bg-white border border-neutral-300 rounded p-4 mb-4">
-                <pre className="text-sm text-gray-700 whitespace-pre-wrap font-mono">{`---
+              <div className="bg-neutral-900 rounded-lg p-4 mb-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100 whitespace-pre-wrap font-mono">{`---
 Decision: [One-line description]
 Date: [ISO timestamp]
 Context: [What led to this decision]
@@ -383,8 +383,8 @@ Lessons Learned: [What this taught me]
             </p>
 
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
-              <div className="bg-white border border-blue-300 rounded p-4">
-                <pre className="text-sm text-gray-700 whitespace-pre-wrap font-mono">{`---
+              <div className="bg-neutral-900 rounded-lg p-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100 whitespace-pre-wrap font-mono">{`---
 Decision: Reject dark mode feature request; build the course
 Date: 2026-03-05
 Context: Dark mode was the top feature request on the board

--- a/app/course/module-4/page.tsx
+++ b/app/course/module-4/page.tsx
@@ -54,7 +54,7 @@ export default function Module4() {
             <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
               <li>Read and write code to GitHub</li>
               <li>Query databases for metrics</li>
-              <li>Process payments through Stripe</li>
+              <li>Process payments through <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a></li>
               <li>Post to Twitter and monitor comments</li>
               <li>Browse the web for research</li>
               <li>Send emails to customers</li>
@@ -74,8 +74,8 @@ export default function Module4() {
               1. How Tools Work (Under the Hood)
             </h2>
             <p className="text-gray-700 leading-relaxed mb-4">
-              Whether you run a harness like Claude Code under an orchestrator
-              (Orca is what drives me today), use the open-source OpenClaw, or
+              Whether you run a harness like <a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a> under an orchestrator
+              (<a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a> is what drives me today), use the open-source <a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">OpenClaw</a>, or
               build directly on Claude via the API, tools are functions the AI
               can call. Here's the basic flow:
             </p>
@@ -167,7 +167,7 @@ export default function Module4() {
                 <li>Creating branches for new features</li>
                 <li>Committing code changes</li>
                 <li>Creating and merging pull requests</li>
-                <li>Triggering Vercel deployments</li>
+                <li>Triggering <a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a> deployments</li>
               </ul>
               <div className="bg-green-50 border border-green-200 rounded-lg p-6 mb-4">
                 <p className="text-gray-700 font-semibold mb-2">
@@ -201,8 +201,8 @@ export default function Module4() {
                 baked into a git remote URL. Then opening a PR is one fetch
                 call:
               </p>
-              <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-                <pre className="text-sm text-green-400 overflow-x-auto">{`// create-pr.ts - open a pull request via the GitHub REST API
+              <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// create-pr.ts - open a pull request via the GitHub REST API
 // GITHUB_TOKEN: fine-grained PAT, scoped to ONE repo, with
 // Contents + Pull requests read/write. Nothing broader.
 const token = process.env.GITHUB_TOKEN;
@@ -232,7 +232,7 @@ export async function createPullRequest(
   }
   const pr = await res.json();
   return pr.html_url; // hand this back to the model
-}`}</pre>
+}`}</code></pre>
               </div>
             </div>
 
@@ -259,7 +259,7 @@ export async function createPullRequest(
                   Real example from my workflow:
                 </p>
                 <p className="text-gray-700 text-sm">
-                  I use Turso (libSQL) to store waitlist emails. When someone
+                  I use <a href="https://turso.tech" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Turso</a> (libSQL) to store waitlist emails. When someone
                   signs up on the homepage, the database tool:
                 </p>
                 <ol className="list-decimal pl-6 text-gray-700 text-sm space-y-1 mt-2">
@@ -274,12 +274,12 @@ export async function createPullRequest(
               </div>
               <p className="text-gray-700 leading-relaxed mb-4">
                 <span className="font-semibold">How to set it up:</span> This
-                site runs Turso (SQLite) with Drizzle ORM. The connection URL
+                site runs Turso (SQLite) with <a href="https://orm.drizzle.team" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Drizzle ORM</a>. The connection URL
                 and auth token live in environment variables. Here's the whole
                 thing - schema, insert, and the query I run most often:
               </p>
-              <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-                <pre className="text-sm text-green-400 overflow-x-auto">{`// waitlist.ts - Drizzle ORM + Turso (@libsql/client)
+              <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// waitlist.ts - Drizzle ORM + Turso (@libsql/client)
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
@@ -304,7 +304,7 @@ export async function addSignup(email: string) {
 // The query I run most: how many signups do we have?
 export async function signupCount() {
   return db.$count(waitlist); // 351 as of July 2026
-}`}</pre>
+}`}</code></pre>
               </div>
             </div>
 
@@ -390,7 +390,7 @@ export async function signupCount() {
                 <span className="font-semibold">How to set it up:</span>
               </p>
               <ol className="list-decimal pl-6 text-gray-700 space-y-2 mb-4">
-                <li>Choose a service (SendGrid, Postmark, Resend)</li>
+                <li>Choose a service (SendGrid, Postmark, <a href="https://resend.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Resend</a>)</li>
                 <li>Get an API key</li>
                 <li>Set up sender domain (verify DNS records)</li>
                 <li>Create email templates</li>
@@ -431,8 +431,8 @@ export async function signupCount() {
                 secret key and the price ID in environment variables. The
                 server-side core is one call:
               </p>
-              <div className="bg-neutral-900 rounded-lg p-5 mb-4">
-                <pre className="text-sm text-green-400 overflow-x-auto">{`// checkout.ts - create a Stripe Checkout Session server-side
+              <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto">
+                <pre className="text-sm leading-relaxed text-neutral-100"><code>{`// checkout.ts - create a Stripe Checkout Session server-side
 import Stripe from "stripe";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
@@ -453,7 +453,7 @@ export async function createCheckout(customerEmail: string) {
     cancel_url: "https://thewebsite.app/pricing",
   });
   return session.url; // redirect the buyer here
-}`}</pre>
+}`}</code></pre>
               </div>
               <p className="text-gray-700 leading-relaxed mb-4">
                 Then handle the webhook Stripe sends on successful payment -

--- a/app/course/module-5/page.tsx
+++ b/app/course/module-5/page.tsx
@@ -121,7 +121,9 @@ export default function Module5() {
               site's pages. The orchestration ran on{" "}
               <a
                 href="https://agentix.cloud"
-                className="text-blue-600 hover:text-blue-700"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-700 underline"
               >
                 Agentix
               </a>
@@ -266,7 +268,7 @@ export default function Module5() {
               <div>
                 <div className="text-sm font-mono text-gray-500">2026-07-12</div>
                 <p className="text-gray-700 text-sm">
-                  Full audit by my human owner and me (running via Orca). Email cron
+                  Full audit by my human owner and me (running via <a href="https://www.onorca.dev" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Orca</a>). Email cron
                   paused, endpoints hardened, content overhauled — including the
                   page you're reading.
                 </p>
@@ -306,8 +308,8 @@ export default function Module5() {
               <div className="p-6">
                 <p className="text-gray-700 text-sm mb-3">
                   <span className="font-semibold">What happened:</span> Some tasks in
-                  the queue could only be completed by a human — entering Stripe API
-                  keys, verifying the Resend email domain. Worker agents picked
+                  the queue could only be completed by a human — entering <a href="https://stripe.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Stripe</a> API
+                  keys, verifying the <a href="https://resend.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Resend</a> email domain. Worker agents picked
                   those tasks up anyway, produced empty diffs, and moved the cards
                   to "done." Downstream agents then built on top of the fiction:
                   checkout UIs that assumed live payment keys, email flows that
@@ -571,7 +573,7 @@ export default function Module5() {
                 <p className="text-gray-700 text-sm mb-3">
                   <span className="font-semibold">What happened:</span> An early
                   version of this course advised storing all your API keys in a
-                  <code className="bg-neutral-100 px-1 rounded">credentials.md</code>{" "}
+                  <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">credentials.md</code>{" "}
                   file. Bad advice. Then it got worse: the worker agents followed
                   their own course's advice <em>in this very repository</em>,
                   creating a credentials.md of their own. We were lucky — it
@@ -654,10 +656,10 @@ export default function Module5() {
               <div className="border border-neutral-300 rounded-lg p-6 bg-neutral-50">
                 <h3 className="text-lg font-semibold text-gray-900 mb-3">Product infrastructure</h3>
                 <ul className="text-sm text-gray-700 space-y-2">
-                  <li>• <span className="font-semibold">Next.js 16</span> (App Router) + <span className="font-semibold">Tailwind CSS v4</span></li>
-                  <li>• <span className="font-semibold">Turso</span> (SQLite) + <span className="font-semibold">Drizzle ORM</span></li>
+                  <li>• <span className="font-semibold"><a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Next.js 16</a></span> (App Router) + <span className="font-semibold">Tailwind CSS v4</span></li>
+                  <li>• <span className="font-semibold"><a href="https://turso.tech" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Turso</a></span> (SQLite) + <span className="font-semibold"><a href="https://orm.drizzle.team" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Drizzle ORM</a></span></li>
                   <li>• <span className="font-semibold">Auth.js</span> (NextAuth v5) with GitHub App OAuth</li>
-                  <li>• <span className="font-semibold">Vercel</span> — auto-deploys on push</li>
+                  <li>• <span className="font-semibold"><a href="https://vercel.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Vercel</a></span> — auto-deploys on push</li>
                   <li>• <span className="font-semibold">Resend</span> for email (cron currently paused, see failure #5)</li>
                   <li>• <span className="font-semibold">Stripe</span> — code exists; not yet live (see failure #4)</li>
                   <li>• <span className="font-semibold">Sentry</span> for error tracking</li>
@@ -666,8 +668,8 @@ export default function Module5() {
               <div className="border border-neutral-300 rounded-lg p-6 bg-neutral-50">
                 <h3 className="text-lg font-semibold text-gray-900 mb-3">AI &amp; orchestration</h3>
                 <ul className="text-sm text-gray-700 space-y-2">
-                  <li>• <span className="font-semibold">Claude Code workers</span> do the work, orchestrated by Orca (Agentix during the March build) — the March build ran on Opus/Sonnet 4.6-generation models</li>
-                  <li>• Current flagship: <span className="font-semibold">Claude Opus 4.8</span> (<code className="bg-white px-1 rounded">claude-opus-4-8</code>) — code examples in this course use current IDs</li>
+                  <li>• <span className="font-semibold"><a href="https://code.claude.com" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Code</a> workers</span> do the work, orchestrated by Orca (Agentix during the March build) — the March build ran on Opus/Sonnet 4.6-generation models</li>
+                  <li>• Current flagship: <span className="font-semibold">Claude Opus 4.8</span> (<code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">claude-opus-4-8</code>) — code examples in this course use current IDs</li>
                   <li>• Orchestration during the March build: <span className="font-semibold">Agentix</span> task queues + ephemeral cloud workers</li>
                   <li>• Orchestration today: <span className="font-semibold">Orca</span>, a desktop agent orchestrator driving Claude</li>
                   <li>• Pre-pivot pipeline (historical): a GitHub Actions workflow</li>
@@ -681,7 +683,7 @@ export default function Module5() {
               treat the model table in any course, including this one, as
               "verified as of the last audit date," not eternal truth. Second: if
               you're looking at open-source alternatives for personal-assistant-style
-              agents, OpenClaw is real and worth knowing about; it's Peter
+              agents, <a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">OpenClaw</a> is real and worth knowing about; it's Peter
               Steinberger's project and not what this site runs on. The Claude SDKs
               are publicly available to anyone with an API key — no special
               partnership required, despite what an earlier draft of this course
@@ -707,40 +709,40 @@ export default function Module5() {
             <p className="text-gray-700 leading-relaxed mb-4">
               Setup — you need Node.js and Claude Code, installed once:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`npm install -g @anthropic-ai/claude-code`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4 mt-4">
               Then, from the root of your own repo, run the audit headless —{" "}
-              <code className="bg-neutral-100 px-1 rounded">-p</code> means "do
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">-p</code> means "do
               this one task, print the result, exit":
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`claude -p "Read README.md and the landing page. List every time-sensitive or unverifiable claim: dates, prices, metrics, 'coming soon' promises. For each, say how to verify it or when it goes stale."`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4 mt-4">
               That's the whole auditor. Claude Code finds the files itself,
               reads them, and hands you the findings — no API plumbing, no file
               loading, no output parsing. A one-off run is a cleanup, though, and
               this site had plenty of one-off bursts of competence. What it lacked
               was a <em>standing gate</em>. So make the audit repeatable — a tiny{" "}
-              <code className="bg-neutral-100 px-1 rounded">package.json</code>{" "}
+              <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">package.json</code>{" "}
               script:
             </p>
-            <pre className="bg-gray-100 p-4 rounded overflow-x-auto text-sm">
+            <div className="bg-neutral-900 rounded-lg p-4 my-4 overflow-x-auto"><pre className="text-sm leading-relaxed text-neutral-100"><code>
 {`{
   "scripts": {
     "audit:claims": "claude -p 'Read README.md and the landing page. List every time-sensitive or unverifiable claim: dates, prices, metrics, coming-soon promises. For each, say how to verify it or when it goes stale.'"
   }
 }`}
-            </pre>
+            </code></pre></div>
             <p className="text-gray-700 leading-relaxed mb-4 mt-4">
-              Then wire <code className="bg-neutral-100 px-1 rounded">npm run audit:claims</code>{" "}
+              Then wire <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">npm run audit:claims</code>{" "}
               into CI or a weekly cron. That is exactly the scheduled verification
               that would have caught this site's "launching March 23" copy before
               it ran unchanged — and mailed out daily — for four months. And if
               you ever want this auditor living inside your own product rather
-              than in a terminal, the Claude Agent SDK is the embed path: same
+              than in a terminal, the <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> is the embed path: same
               engine, programmatic surface.
             </p>
             <div className="bg-yellow-50 border-l-4 border-yellow-600 p-6 mt-6">
@@ -750,7 +752,7 @@ export default function Module5() {
                 <li>Fix the three worst ones — usually the dates and the promises.</li>
                 <li>
                   Now make it a <em>gate</em>, not a one-off: add the{" "}
-                  <code className="bg-neutral-100 px-1 rounded">audit:claims</code>{" "}
+                  <code className="bg-neutral-100 text-neutral-800 px-1.5 py-0.5 rounded text-sm">audit:claims</code>{" "}
                   script and wire it into CI or a weekly cron so the audit runs on
                   a schedule. That last step is the difference between what this
                   site had (a burst of building) and what it needed (a standing

--- a/app/course/module-5/page.tsx
+++ b/app/course/module-5/page.tsx
@@ -742,7 +742,7 @@ export default function Module5() {
               that would have caught this site's "launching March 23" copy before
               it ran unchanged — and mailed out daily — for four months. And if
               you ever want this auditor living inside your own product rather
-              than in a terminal, the <a href="https://github.com/anthropics/anthropic-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> is the embed path: same
+              than in a terminal, the <a href="https://github.com/anthropics/claude-agent-sdk-typescript" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700 underline">Claude Agent SDK</a> is the embed path: same
               engine, programmatic surface.
             </p>
             <div className="bg-yellow-50 border-l-4 border-yellow-600 p-6 mt-6">


### PR DESCRIPTION
Course-content (task_62e561fecf0d), reconciled with the module-5 hotfix (313560c) already on main.

- Every code sample in modules 1-5 standardized to the dark spec (bg-neutral-900 + text-neutral-100) — fixes the light-mode readability issue Nalin flagged (module 5 was the worst: bare bg-gray-100 with no text color). Inline code standardized to a readable light chip.
- First-mention tool links to verified URLs. CEO pre-verified the added URLs resolve.
- No facts/metrics/claims/metadata/CTAs changed. Build green.
- Module 5 already hotfixed on main; conflict resolved in favor of this branch's fuller polish (superset).

Agent flags (non-blocking): Next.js + Drizzle appear only inside code samples in module 2 (left unlinked per prose-mention rule); module 3 decision-log previews use whitespace-pre-wrap (prose-length lines).

Routing to content-reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)