### PR TITLE
Fix /activity revenue: sum real pack_purchases sales (#105)

### DIFF
--- a/app/api/webhook/stripe/__tests__/route.test.ts
+++ b/app/api/webhook/stripe/__tests__/route.test.ts
@@ -40,6 +40,7 @@ function completedSessionEvent() {
         payment_intent: 'pi_test_123',
         customer_email: null,
         customer_details: { email: 'buyer@example.com' },
+        amount_total: 9900,
         payment_status: 'paid',
       },
     },
@@ -64,7 +65,8 @@ describe('Stripe webhook (pack presale)', () => {
     expect(markPurchaseCompleted).toHaveBeenCalledWith(
       'cs_test_abc123',
       'pi_test_123',
-      'buyer@example.com'
+      'buyer@example.com',
+      9900
     );
   });
 

--- a/app/api/webhook/stripe/route.ts
+++ b/app/api/webhook/stripe/route.ts
@@ -48,7 +48,12 @@ export async function POST(req: Request) {
           ? session.payment_intent
           : session.payment_intent?.id ?? null;
 
-      await markPurchaseCompleted(session.id, paymentIntentId, email);
+      await markPurchaseCompleted(
+        session.id,
+        paymentIntentId,
+        email,
+        session.amount_total
+      );
       console.log(`[WEBHOOK] pack purchase completed: ${session.id}`);
       break;
     }

--- a/app/pack/success/page.tsx
+++ b/app/pack/success/page.tsx
@@ -37,7 +37,12 @@ async function verifySession(
         : session.payment_intent?.id ?? null;
 
     // Belt and braces alongside the webhook; idempotent.
-    await markPurchaseCompleted(session.id, paymentIntentId, email);
+    await markPurchaseCompleted(
+      session.id,
+      paymentIntentId,
+      email,
+      session.amount_total
+    );
 
     return {
       email,

--- a/lib/__tests__/presale.test.ts
+++ b/lib/__tests__/presale.test.ts
@@ -29,43 +29,51 @@ function sqlText(callIndex: number): string {
     .join(' ');
 }
 
+// ensureTable() runs two statements before any real query: CREATE TABLE (call
+// index 0) and the idempotent ALTER TABLE ADD COLUMN amount_cents (index 1).
+// So the operation's own statement starts at index 2.
 describe('pack_purchases status transitions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('completes an existing pending row via UPDATE only', async () => {
-    // ensureTable, then UPDATE affecting 1 row → no INSERT fallback
+  it('completes an existing pending row via UPDATE, storing amount_cents', async () => {
     runMock.mockResolvedValueOnce({}); // CREATE TABLE
+    runMock.mockResolvedValueOnce({}); // ALTER TABLE ADD COLUMN
     runMock.mockResolvedValueOnce({ rowsAffected: 1 }); // UPDATE
 
-    await markPurchaseCompleted('cs_1', 'pi_1', 'a@example.com');
+    await markPurchaseCompleted('cs_1', 'pi_1', 'a@example.com', 9900);
 
-    expect(runMock).toHaveBeenCalledTimes(2);
-    expect(sqlText(1)).toContain('UPDATE pack_purchases');
-    expect(sqlText(1)).toContain("status != 'refunded'");
+    expect(runMock).toHaveBeenCalledTimes(3);
+    expect(sqlText(2)).toContain('UPDATE pack_purchases');
+    expect(sqlText(2)).toContain("status != 'refunded'");
+    expect(sqlText(2)).toContain('amount_cents'); // revenue is recorded
   });
 
-  it('upserts a completed row when no pending row exists (webhook is source of truth)', async () => {
+  it('upserts a completed row with amount_cents when no pending row exists', async () => {
     runMock.mockResolvedValueOnce({}); // CREATE TABLE
+    runMock.mockResolvedValueOnce({}); // ALTER TABLE ADD COLUMN
     runMock.mockResolvedValueOnce({ rowsAffected: 0 }); // UPDATE missed
     runMock.mockResolvedValueOnce({}); // INSERT fallback
 
-    await markPurchaseCompleted('cs_2', 'pi_2', null);
+    await markPurchaseCompleted('cs_2', 'pi_2', null, 9900);
 
-    expect(runMock).toHaveBeenCalledTimes(3);
-    expect(sqlText(2)).toContain('INSERT INTO pack_purchases');
-    expect(sqlText(2)).toContain("'completed'");
+    expect(runMock).toHaveBeenCalledTimes(4);
+    expect(sqlText(3)).toContain('INSERT INTO pack_purchases');
+    expect(sqlText(3)).toContain("'completed'");
+    expect(sqlText(3)).toContain('amount_cents');
   });
 
   it('records a refund by payment intent and reports whether a row matched', async () => {
     runMock.mockResolvedValueOnce({}); // CREATE TABLE
+    runMock.mockResolvedValueOnce({}); // ALTER TABLE ADD COLUMN
     runMock.mockResolvedValueOnce({ rowsAffected: 1 }); // UPDATE
 
     await expect(markPurchaseRefunded('pi_1')).resolves.toBe(true);
-    expect(sqlText(1)).toContain("SET status = 'refunded'");
+    expect(sqlText(2)).toContain("SET status = 'refunded'");
 
     runMock.mockResolvedValueOnce({}); // CREATE TABLE
+    runMock.mockResolvedValueOnce({}); // ALTER TABLE ADD COLUMN
     runMock.mockResolvedValueOnce({ rowsAffected: 0 });
     await expect(markPurchaseRefunded('pi_unknown')).resolves.toBe(false);
   });

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -170,7 +170,7 @@ export async function getPublicStats(): Promise<PublicStats> {
       sql`SELECT COUNT(DISTINCT email) as count FROM funnel_events WHERE event = 'confirm'`
     ),
     count(
-      sql`SELECT COALESCE(SUM(amount_cents), 0) as count FROM purchases WHERE status = 'completed'`
+      sql`SELECT COALESCE(SUM(amount_cents), 0) as count FROM pack_purchases WHERE status = 'completed'`
     ),
   ]);
 

--- a/lib/presale.ts
+++ b/lib/presale.ts
@@ -22,6 +22,7 @@ export interface PackPurchase {
   stripe_payment_intent_id: string | null;
   email: string | null;
   status: PackPurchaseStatus;
+  amount_cents: number | null;
   created_at: string;
   completed_at: string | null;
 }
@@ -40,10 +41,19 @@ async function ensureTable() {
       stripe_payment_intent_id TEXT,
       email TEXT,
       status TEXT NOT NULL DEFAULT 'pending',
+      amount_cents INTEGER,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       completed_at DATETIME
     )
   `);
+  // Existing prod tables predate amount_cents; add it if missing. SQLite
+  // throws if the column already exists — expected on every run after the
+  // first, so swallow it.
+  try {
+    await db.run(sql`ALTER TABLE pack_purchases ADD COLUMN amount_cents INTEGER`);
+  } catch {
+    // Column already present.
+  }
 }
 
 type RawRows = { rows?: Array<Record<string, unknown>> };
@@ -57,6 +67,7 @@ function mapRow(row: Record<string, unknown>): PackPurchase {
       : null,
     email: row.email ? String(row.email) : null,
     status: String(row.status) as PackPurchaseStatus,
+    amount_cents: row.amount_cents != null ? Number(row.amount_cents) : null,
     created_at: String(row.created_at),
     completed_at: row.completed_at ? String(row.completed_at) : null,
   };
@@ -80,7 +91,8 @@ export async function createPendingPurchase(
 export async function markPurchaseCompleted(
   sessionId: string,
   paymentIntentId: string | null,
-  email: string | null
+  email: string | null,
+  amountCents: number | null
 ): Promise<void> {
   await ensureTable();
   const normalizedEmail = email?.toLowerCase().slice(0, 254) ?? null;
@@ -89,6 +101,7 @@ export async function markPurchaseCompleted(
     SET status = 'completed',
         stripe_payment_intent_id = COALESCE(${paymentIntentId}, stripe_payment_intent_id),
         email = COALESCE(${normalizedEmail}, email),
+        amount_cents = COALESCE(${amountCents}, amount_cents),
         completed_at = COALESCE(completed_at, CURRENT_TIMESTAMP)
     WHERE stripe_session_id = ${sessionId} AND status != 'refunded'
   `);
@@ -97,9 +110,9 @@ export async function markPurchaseCompleted(
   if (updated === 0) {
     await db.run(sql`
       INSERT INTO pack_purchases
-        (stripe_session_id, stripe_payment_intent_id, email, status, completed_at)
+        (stripe_session_id, stripe_payment_intent_id, email, status, amount_cents, completed_at)
       VALUES
-        (${sessionId}, ${paymentIntentId}, ${normalizedEmail}, 'completed', CURRENT_TIMESTAMP)
+        (${sessionId}, ${paymentIntentId}, ${normalizedEmail}, 'completed', ${amountCents}, CURRENT_TIMESTAMP)
       ON CONFLICT(stripe_session_id) DO NOTHING
     `);
   }
@@ -125,7 +138,7 @@ export async function getPurchaseBySession(
   await ensureTable();
   const result = await db.run(sql`
     SELECT id, stripe_session_id, stripe_payment_intent_id, email, status,
-           created_at, completed_at
+           amount_cents, created_at, completed_at
     FROM pack_purchases
     WHERE stripe_session_id = ${sessionId}
     LIMIT 1


### PR DESCRIPTION
Engineer (#105). /activity showed Revenue $0 despite the real $99 sale — getPublicStats summed the empty 'purchases' table, and pack_purchases had no amount column.

- Added amount_cents to pack_purchases (CREATE + idempotent ALTER in ensureTable)
- Threaded session.amount_total through markPurchaseCompleted (webhook + success page)
- Revenue query → SUM(amount_cents) FROM pack_purchases WHERE status='completed'
- Tests: webhook asserts 9900 forwarded; presale asserts amount written on UPDATE + INSERT paths. Build green.

Payment/webhook code → code-reviewer gate. Prod backfill (CEO data step) run separately.