### PR TITLE
Harden analytics track + fix module-count/revenue drift (fixes #100)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,15 +7,16 @@ export const metadata = {
 };
 
 const MODULE_NAMES: Record<number, string> = {
-  1: "AI Agent Architecture",
-  2: "Building Your First Agent",
+  1: "Automation vs. Autonomy",
+  2: "Setting Up Your Agent Environment",
   3: "Autonomous Decision Making",
-  4: "Integrating with Real Tools",
-  5: "Case Study: The Website",
+  4: "Integrating AI Agents with Real Tools",
+  5: "Case Study — The Website: What Actually Happened",
   6: "Building Multi-Agent Teams",
-  7: "Production Best Practices",
+  7: "Production AI Agent Best Practices",
   8: "Deployment & Scaling",
   9: "Building Your First AI Agent Business",
+  10: "Case Studies & Real-World Examples",
 };
 
 function formatSeconds(seconds: number): string {
@@ -104,7 +105,7 @@ export default async function AdminPage() {
             </div>
           ) : (
             <div className="space-y-3">
-              {Array.from({ length: 9 }, (_, i) => i + 1).map((moduleId) => {
+              {Array.from({ length: 10 }, (_, i) => i + 1).map((moduleId) => {
                 const stat = analytics.moduleStats.find((m) => Number(m.module_id) === moduleId);
                 const students = stat ? Number(stat.unique_students) : 0;
                 const avgTime = stat ? Number(stat.avg_time_spent) : 0;
@@ -179,7 +180,7 @@ export default async function AdminPage() {
                 Percentage of students who continue from one module to the next.
               </p>
               <div className="space-y-2">
-                {Array.from({ length: 8 }, (_, i) => {
+                {Array.from({ length: 9 }, (_, i) => {
                   const fromMod = i + 1;
                   const toMod = i + 2;
                   const fromStat = analytics.moduleStats.find(

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -73,9 +73,9 @@ async function getAnalyticsData() {
     safeQuery("SELECT COUNT(*) as count FROM email_subscribers WHERE welcome_sent_at IS NOT NULL"),
     safeQuery("SELECT COUNT(*) as count FROM email_subscribers WHERE day3_sent_at IS NOT NULL"),
     safeQuery("SELECT COUNT(*) as count FROM email_subscribers WHERE day7_sent_at IS NOT NULL"),
-    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed'"),
-    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed' AND date(completed_at) = date('now')"),
-    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed' AND completed_at >= datetime('now', '-7 days')"),
+    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed'"),
+    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed' AND date(completed_at) = date('now')"),
+    safeQuery("SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed' AND completed_at >= datetime('now', '-7 days')"),
     safeQuery("SELECT COUNT(*) as count FROM page_views"),
     safeQuery("SELECT COUNT(*) as count FROM page_views WHERE date(created_at) = date('now')"),
     safeQuery("SELECT COUNT(*) as count FROM page_views WHERE created_at >= datetime('now', '-7 days')"),
@@ -456,12 +456,14 @@ export default async function AnalyticsPage() {
                   </div>
                 </div>
                 <div>
-                  <div className="text-xs text-neutral-600 mb-1">Goal: $80,000/mo</div>
-                  <div className="w-full bg-neutral-800 rounded-full h-2">
-                    <div
-                      className="bg-green-600 h-2 rounded-full"
-                      style={{ width: `${Math.min(100, (data.revenue.weekCents / 4 / 8000000) * 100)}%` }}
-                    />
+                  <div className="text-xs text-neutral-600 mb-1">
+                    Projected monthly run-rate (last 7 days &times; 4.3)
+                  </div>
+                  <div className="text-lg font-bold text-white">
+                    {fmt$(Math.round((data.revenue.weekCents * 52) / 12))}
+                  </div>
+                  <div className="text-xs text-neutral-600">
+                    Extrapolated from recent revenue — not a target.
                   </div>
                 </div>
               </div>

--- a/app/api/analytics/data/route.ts
+++ b/app/api/analytics/data/route.ts
@@ -57,17 +57,17 @@ export async function GET(request: NextRequest) {
 
   // ---- Revenue ----
   const revenueTotal = await safeQuery(
-    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed'"
+    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed'"
   );
   const revenueToday = await safeQuery(
-    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed' AND date(completed_at) = date('now')"
+    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed' AND date(completed_at) = date('now')"
   );
   const revenueWeek = await safeQuery(
-    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM purchases WHERE status = 'completed' AND completed_at >= datetime('now', '-7 days')"
+    "SELECT COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count FROM pack_purchases WHERE status = 'completed' AND completed_at >= datetime('now', '-7 days')"
   );
   const revenueByDay = await safeQuery(
     `SELECT date(completed_at) as day, COALESCE(SUM(amount_cents), 0) as total, COUNT(*) as count
-     FROM purchases
+     FROM pack_purchases
      WHERE status = 'completed' AND completed_at >= datetime('now', '-30 days')
      GROUP BY date(completed_at)
      ORDER BY day ASC`

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -8,25 +8,92 @@ function getDbClient() {
   });
 }
 
-async function ensurePageViewsTable(client: ReturnType<typeof createClient>) {
-  await client.execute(`
-    CREATE TABLE IF NOT EXISTS page_views (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      path TEXT NOT NULL,
-      referrer TEXT,
-      utm_source TEXT,
-      utm_medium TEXT,
-      utm_campaign TEXT,
-      session_id TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-    )
-  `);
+// One-time table init, memoized for the life of the server instance: the DDL
+// runs at most once per cold start, never on every request. If it fails, the
+// guard resets so a later request can retry. (page_views is a runtime table —
+// the protected lib/schema.ts is not touched.)
+let pageViewsReady: Promise<void> | null = null;
+function ensurePageViewsTable(
+  client: ReturnType<typeof createClient>
+): Promise<void> {
+  if (!pageViewsReady) {
+    pageViewsReady = client
+      .execute(`
+        CREATE TABLE IF NOT EXISTS page_views (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          path TEXT NOT NULL,
+          referrer TEXT,
+          utm_source TEXT,
+          utm_medium TEXT,
+          utm_campaign TEXT,
+          session_id TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+      `)
+      .then(() => undefined)
+      .catch((err) => {
+        pageViewsReady = null; // allow a later request to retry the init
+        throw err;
+      });
+  }
+  return pageViewsReady;
+}
+
+// Light in-memory rate limit (per server instance). Not a hard cross-instance
+// guarantee, but combined with the same-origin check it blunts metric-poisoning
+// floods without adding a dependency. Real users fire ~1 event per page view.
+const RATE_MAX = 60; // events per window per IP
+const RATE_WINDOW_MS = 10_000;
+const rateHits = new Map<string, { count: number; resetAt: number }>();
+function isRateLimited(key: string): boolean {
+  const now = Date.now();
+  const entry = rateHits.get(key);
+  if (!entry || now > entry.resetAt) {
+    rateHits.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    // Opportunistic cleanup so the map can't grow unbounded.
+    if (rateHits.size > 5000) {
+      for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
+    }
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > RATE_MAX;
+}
+
+// Same-origin guard: real page-view beacons carry an Origin (POST) or a
+// Referer whose host matches ours. Direct scripted POSTs (curl/bots aiming to
+// poison metrics) carry neither, so they're rejected.
+function isSameOrigin(request: NextRequest): boolean {
+  const host = request.headers.get("host");
+  if (!host) return false;
+  for (const header of ["origin", "referer"] as const) {
+    const value = request.headers.get(header);
+    if (!value) continue;
+    try {
+      if (new URL(value).host === host) return true;
+    } catch {
+      // malformed header — ignore and try the next
+    }
+  }
+  return false;
 }
 
 export async function POST(request: NextRequest) {
   try {
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ ok: false }, { status: 403 });
+    }
+
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      "unknown";
+    if (isRateLimited(ip)) {
+      return NextResponse.json({ ok: false }, { status: 429 });
+    }
+
     const body = await request.json();
-    const { path, referrer, utm_source, utm_medium, utm_campaign, session_id } = body;
+    const { path, referrer, utm_source, utm_medium, utm_campaign, session_id } =
+      body;
 
     if (!path || typeof path !== "string" || !path.startsWith("/")) {
       return NextResponse.json({ error: "Invalid path" }, { status: 400 });
@@ -50,7 +117,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (error) {
-    // Silently fail — tracking should never break the user experience
+    // Silently fail — tracking should never break the user experience.
     console.error("Analytics track error:", error);
     return NextResponse.json({ ok: false }, { status: 200 });
   }

--- a/app/api/course/completion/route.ts
+++ b/app/api/course/completion/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/session";
 
-const TOTAL_MODULES = 8;
+const TOTAL_MODULES = 10;
 const ALL_MODULE_IDS = Array.from({ length: TOTAL_MODULES }, (_, i) => i + 1);
 
 export async function POST(req: NextRequest) {

--- a/app/api/course/progress/route.ts
+++ b/app/api/course/progress/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (typeof moduleId !== "number" || moduleId < 1 || moduleId > 20) {
+    if (typeof moduleId !== "number" || moduleId < 1 || moduleId > 10) {
       return NextResponse.json({ error: "Invalid moduleId" }, { status: 400 });
     }
 


### PR DESCRIPTION
Scope: GitHub issue #100 (+ the phantom-revenue-table follow-up from the PR #106 review).

## What changed
1. **`/api/analytics/track` hardened** (was public/unthrottled/per-request DDL — a metric-poisoning vector):
   - Same-origin guard: `Origin`/`Referer` host must match `Host`. Real page-view beacons (sendBeacon/fetch POST) carry it; scripted curl/bot POSTs don't.
   - Light in-memory per-IP rate limit (60 events / 10s).
   - `page_views` table creation moved out of the request path to a memoized one-time init (runs once per server instance, not on every request).
2. **Module-count drift → all 10:** admin module list `9→10` and drop-off `8→9` transitions (plus corrected `MODULE_NAMES`, incl. module 10, from COURSE_FACTS); `/api/course/completion` `TOTAL_MODULES 8→10`; `/api/course/progress` cap `20→10`.
3. **Banned fabricated target removed:** admin analytics `$80,000/mo` goal → honest, clearly-labeled projected monthly run-rate from real revenue (admin-only, but still a banned claim).
4. **Admin revenue phantom table fixed** (PR #106 review follow-up): the admin analytics API route and the analytics page summed the empty `purchases` table → now sum the real `pack_purchases` (`status='completed'`), so admin revenue matches `/activity`'s corrected **$99**.

## Verification (live-probed, not just built)
- `pnpm build` green.
- `POST /api/analytics/track`: **403** with no Origin/Referer, **403** cross-origin, **200** same-origin, **429** under a 65-request flood.
- `GET /api/course/completion` → `totalModules: 10`, moduleIds 1–10.
- Revenue query against `pack_purchases` returns **$99** (pending rows excluded), matching `/activity`.

## Notes
- No new dependencies. The rate limit + init guard are in-memory (per server instance) — a deliberate no-dep "light" limit that pairs with the same-origin check; noted for the reviewer.
- No protected files touched; no subscriber emails/PII rendered or logged.

Substantive + payment-adjacent code → **code-reviewer gate**.