### PR TITLE
Public testimonials submission + lead-magnet success states (fixes #99)

### DIFF
--- a/app/api/testimonials/__tests__/route.test.ts
+++ b/app/api/testimonials/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST, validateTestimonialSubmission } from '../route';
+
+// The route also touches the DB on the (untestable-in-unit) same-origin-pass
+// path; mock it so importing the module doesn't try to open a connection.
+vi.mock('@/lib/testimonials-db', () => ({
+  initTestimonialsTable: vi.fn().mockResolvedValue(undefined),
+  recordSubmitterEmail: vi.fn().mockResolvedValue(undefined),
+  testimonialsDb: { insert: () => ({ values: () => ({ returning: vi.fn() }) }) },
+}));
+vi.mock('@/lib/testimonials-schema', () => ({ testimonials: {} }));
+vi.mock('@/lib/session', () => ({ getSession: vi.fn().mockResolvedValue(null) }));
+
+// --- Pure submission logic (fully testable, no headers/DB) ---
+describe('validateTestimonialSubmission', () => {
+  it('requires name and testimonial text', () => {
+    expect(validateTestimonialSubmission({ name: "Ada" }, false).ok).toBe(false);
+    expect(validateTestimonialSubmission({ testimonialText: "hi" }, false).ok).toBe(false);
+  });
+
+  it('aligns the form field name testimonialText -> testimonial', () => {
+    const r = validateTestimonialSubmission(
+      { name: "Ada", testimonialText: "Great course", rating: 5, consentPublic: true },
+      false
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.values.testimonial).toBe("Great course");
+  });
+
+  it('requires consent for public (non-admin) submissions', () => {
+    const r = validateTestimonialSubmission(
+      { name: "Ada", testimonialText: "Great", rating: 5, consentPublic: false },
+      false
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/consent/i);
+  });
+
+  it('forces public submissions to unpublished (featured=false)', () => {
+    const r = validateTestimonialSubmission(
+      { name: "Ada", testimonialText: "Great", rating: 5, consentPublic: true, featured: true },
+      false // not admin — cannot self-publish
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.values.featured).toBe(false);
+      expect(r.values.consent).toBe(true);
+      expect(r.values.rating).toBe(5);
+    }
+  });
+
+  it('lets an admin publish directly (featured honored, no consent needed)', () => {
+    const r = validateTestimonialSubmission(
+      { name: "Ada", testimonial: "Curated", featured: true },
+      true // admin
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.values.featured).toBe(true);
+  });
+
+  it('rejects an out-of-range rating', () => {
+    expect(
+      validateTestimonialSubmission(
+        { name: "Ada", testimonialText: "Great", rating: 9, consentPublic: true },
+        false
+      ).ok
+    ).toBe(false);
+  });
+});
+
+// --- Route-level same-origin gate (scripted POST has no forgeable Origin) ---
+describe('POST /api/testimonials same-origin gate', () => {
+  it('rejects a scripted POST with no matching Origin/Referer (403)', async () => {
+    const req = new NextRequest('http://localhost:3000/api/testimonials', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Bot', testimonialText: 'spam', rating: 5, consentPublic: true }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/testimonials/route.ts
+++ b/app/api/testimonials/route.ts
@@ -1,13 +1,125 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { eq, desc } from "drizzle-orm";
 import {
   testimonialsDb,
   initTestimonialsTable,
+  recordSubmitterEmail,
 } from "@/lib/testimonials-db";
 import { testimonials } from "@/lib/testimonials-schema";
 import { getSession } from "@/lib/session";
 
+// Same-origin guard + light in-memory rate limit, mirroring /api/analytics/track:
+// real submissions come from our own /testimonials page (Origin/Referer host
+// matches Host); scripted spam POSTs don't. The limit is per server instance —
+// not a hard cross-instance guarantee, but it blunts submission floods with no
+// dependency.
+const RATE_MAX = 10; // submissions per window per IP
+const RATE_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const rateHits = new Map<string, { count: number; resetAt: number }>();
+function isRateLimited(key: string): boolean {
+  const now = Date.now();
+  const entry = rateHits.get(key);
+  if (!entry || now > entry.resetAt) {
+    rateHits.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    if (rateHits.size > 5000) {
+      for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
+    }
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > RATE_MAX;
+}
+
+export interface TestimonialValues {
+  name: string;
+  role: string | null;
+  company: string | null;
+  testimonial: string;
+  avatarUrl: string | null;
+  rating: number | null;
+  consent: boolean;
+  featured: boolean;
+}
+export type SubmissionResult =
+  | { ok: true; values: TestimonialValues }
+  | { ok: false; error: string };
+
+// Pure validation + normalization of a testimonial submission — no DB, no
+// headers — so it's fully unit-testable. Aligns the form's field names
+// (testimonialText/consentPublic) with the admin client's (testimonial/featured).
+export function validateTestimonialSubmission(
+  body: Record<string, unknown>,
+  isAdmin: boolean
+): SubmissionResult {
+  const rawText =
+    typeof body.testimonial === "string" && body.testimonial.trim()
+      ? body.testimonial
+      : (body.testimonialText as unknown);
+  const text = typeof rawText === "string" ? rawText : undefined;
+  const consent = Boolean(body.consent ?? body.consentPublic);
+
+  if (
+    !body.name ||
+    typeof body.name !== "string" ||
+    !text ||
+    typeof text !== "string"
+  ) {
+    return { ok: false, error: "name and testimonial are required" };
+  }
+
+  let rating: number | null = null;
+  const rawRating = body.rating;
+  if (rawRating !== undefined && rawRating !== null && rawRating !== 0) {
+    const r = Number(rawRating);
+    if (!Number.isInteger(r) || r < 1 || r > 5) {
+      return { ok: false, error: "rating must be an integer 1-5" };
+    }
+    rating = r;
+  }
+
+  // Public submitters must consent to public display; admins are curating.
+  if (!isAdmin && !consent) {
+    return {
+      ok: false,
+      error: "Please consent to public display of your testimonial.",
+    };
+  }
+
+  return {
+    ok: true,
+    values: {
+      name: body.name.slice(0, 100),
+      role: body.role ? String(body.role).slice(0, 100) : null,
+      company: body.company ? String(body.company).slice(0, 100) : null,
+      testimonial: text.slice(0, 2000),
+      avatarUrl: body.avatarUrl ? String(body.avatarUrl).slice(0, 500) : null,
+      rating,
+      consent: isAdmin ? true : consent,
+      featured: isAdmin ? Boolean(body.featured) : false,
+    },
+  };
+}
+
+function isSameOrigin(request: NextRequest): boolean {
+  // Prefer the Host header (the public host in production); fall back to the
+  // request URL's host (the Host header is a forbidden header the platform
+  // sets, and it's absent on synthetic requests).
+  const host = request.headers.get("host") || request.nextUrl.host;
+  if (!host) return false;
+  for (const header of ["origin", "referer"] as const) {
+    const value = request.headers.get(header);
+    if (!value) continue;
+    try {
+      if (new URL(value).host === host) return true;
+    } catch {
+      // malformed header — ignore
+    }
+  }
+  return false;
+}
+
 // GET /api/testimonials?featured=true
+// Safe to select all columns: PII (submitter email) is NOT in this table.
 export async function GET(request: Request) {
   try {
     await initTestimonialsTable();
@@ -34,41 +146,52 @@ export async function GET(request: Request) {
   }
 }
 
-// POST /api/testimonials (admin only)
-export async function POST(request: Request) {
+// POST /api/testimonials
+// Public path: an unauthenticated visitor submits a testimonial. It is created
+// unpublished (featured=0), pending admin review. Admins may create featured
+// rows directly. Submitter email (if given) is stored PII-isolated and never
+// echoed back.
+export async function POST(request: NextRequest) {
   try {
-    const session = await getSession();
-    if (!session?.user?.isAdmin) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      "unknown";
+    if (isRateLimited(ip)) {
+      return NextResponse.json(
+        { error: "Too many submissions. Please try again later." },
+        { status: 429 }
+      );
     }
 
     await initTestimonialsTable();
 
-    const body = await request.json();
-    const { name, role, company, testimonial, avatarUrl, featured } = body;
+    const session = await getSession();
+    const isAdmin = Boolean(session?.user?.isAdmin);
 
-    if (!name || !testimonial) {
-      return NextResponse.json(
-        { error: "name and testimonial are required" },
-        { status: 400 }
-      );
+    const body = await request.json();
+
+    const result = validateTestimonialSubmission(body, isAdmin);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
     }
 
     const [created] = await testimonialsDb
       .insert(testimonials)
-      .values({
-        name,
-        role: role || null,
-        company: company || null,
-        testimonial,
-        avatarUrl: avatarUrl || null,
-        featured: featured ?? false,
-      })
+      .values(result.values)
       .returning();
+
+    // Store the submitter email PII-isolated (separate table). Never echoed.
+    const submitterEmail = body.submitterEmail;
+    if (typeof submitterEmail === "string" && submitterEmail.trim()) {
+      await recordSubmitterEmail(created.id, submitterEmail);
+    }
 
     return NextResponse.json(created, { status: 201 });
   } catch (error) {
     console.error("POST /api/testimonials error:", error);
-    return NextResponse.json({ error: String(error) }, { status: 500 });
+    return NextResponse.json({ error: "Failed to submit" }, { status: 500 });
   }
 }

--- a/app/api/waitlist/__tests__/route.test.ts
+++ b/app/api/waitlist/__tests__/route.test.ts
@@ -146,5 +146,57 @@ describe('Waitlist API', () => {
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('success=joined');
     });
+
+    it('redirects to a same-origin `next` path so the page shows its own success state', async () => {
+      const formData = new FormData();
+      formData.append('email', 'lead@example.com');
+      formData.append('next', '/free-guide');
+
+      const request = new NextRequest('http://localhost:3000/api/waitlist', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const location = response.headers.get('location') ?? '';
+
+      expect(response.status).toBe(307);
+      expect(location).toContain('/free-guide?success=joined');
+    });
+
+    it('blocks open-redirect: a protocol-relative `next` falls back to the homepage', async () => {
+      const formData = new FormData();
+      formData.append('email', 'lead@example.com');
+      formData.append('next', '//evil.com');
+
+      const request = new NextRequest('http://localhost:3000/api/waitlist', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const location = response.headers.get('location') ?? '';
+
+      expect(response.status).toBe(307);
+      expect(location).not.toContain('evil.com');
+      expect(location).toBe('http://localhost:3000/?success=joined');
+    });
+
+    it('carries a same-origin `next` through to the error redirect too', async () => {
+      const formData = new FormData();
+      formData.append('email', 'not-an-email');
+      formData.append('next', '/starter-kit');
+
+      const request = new NextRequest('http://localhost:3000/api/waitlist', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const location = response.headers.get('location') ?? '';
+
+      expect(response.status).toBe(307);
+      expect(location).toContain('/starter-kit?error=invalid_email');
+    });
   });
 });

--- a/app/api/waitlist/__tests__/route.test.ts
+++ b/app/api/waitlist/__tests__/route.test.ts
@@ -182,6 +182,29 @@ describe('Waitlist API', () => {
       expect(location).toBe('http://localhost:3000/?success=joined');
     });
 
+    it('blocks a dot-less protocol-relative `next` (//evil resolves off-origin)', async () => {
+      // Regression for the PR #109 review: "//evil" contains no dot, so it slips
+      // past a char-class regex but new URL("//evil", origin) -> http://evil/.
+      for (const evil of ['//evil', '///evil', '//evil/path']) {
+        const formData = new FormData();
+        formData.append('email', 'lead@example.com');
+        formData.append('next', evil);
+
+        const request = new NextRequest('http://localhost:3000/api/waitlist', {
+          method: 'POST',
+          body: formData,
+        });
+
+        const response = await POST(request);
+        const location = response.headers.get('location') ?? '';
+
+        expect(response.status).toBe(307);
+        // Must stay on our origin, never resolve to http://evil/...
+        expect(new URL(location).host).toBe('localhost:3000');
+        expect(location).toBe('http://localhost:3000/?success=joined');
+      }
+    });
+
     it('carries a same-origin `next` through to the error redirect too', async () => {
       const formData = new FormData();
       formData.append('email', 'not-an-email');

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -4,13 +4,25 @@ import { sql } from "drizzle-orm";
 import { addEmailSubscriber, sendWelcomeEmail } from "@/lib/nurture-emails";
 import { trackReferral } from "@/lib/referrals";
 
+// Open-redirect guard: only accept a same-origin, relative path (a single
+// leading "/", no protocol-relative "//", no scheme, no query). Anything else
+// (including "//evil.com") falls back to the homepage. Lead-magnet pages pass
+// their own path here so they can show their own success state.
+function sanitizeReturnPath(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  return /^\/[A-Za-z0-9/_-]*$/.test(value) ? value : null;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData();
     const email = formData.get("email") as string;
+    const returnPath = sanitizeReturnPath(formData.get("next"));
+    const dest = (status: string) =>
+      `${returnPath ?? "/"}?${status}`;
 
     if (!email || !email.includes("@")) {
-      return NextResponse.redirect(new URL("/?error=invalid_email", request.url));
+      return NextResponse.redirect(new URL(dest("error=invalid_email"), request.url));
     }
 
     // Create waitlist table if it doesn't exist
@@ -61,9 +73,10 @@ export async function POST(request: NextRequest) {
       console.error("Email subscriber error:", err);
     }
 
-    // Redirect to success page; clear ref_code cookie on the way out
+    // Redirect to the success state (the lead-magnet page's own, if it passed a
+    // same-origin `next`; otherwise the homepage). Clear ref_code on the way out.
     const successResponse = NextResponse.redirect(
-      new URL("/?success=joined", request.url)
+      new URL(dest("success=joined"), request.url)
     );
     successResponse.cookies.set("ref_code", "", { maxAge: 0, path: "/" });
     return successResponse;

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -10,7 +10,10 @@ import { trackReferral } from "@/lib/referrals";
 // their own path here so they can show their own success state.
 function sanitizeReturnPath(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
-  return /^\/[A-Za-z0-9/_-]*$/.test(value) ? value : null;
+  // The (?!\/) lookahead rejects ANY protocol-relative value ("//evil",
+  // "///evil", "//evil/path"), which new URL() would resolve to an off-origin
+  // host — not just the dotted "//evil.com" case.
+  return /^\/(?!\/)[A-Za-z0-9/_-]*$/.test(value) ? value : null;
 }
 
 export async function POST(request: NextRequest) {

--- a/app/free-guide/page.tsx
+++ b/app/free-guide/page.tsx
@@ -161,6 +161,7 @@ export default function FreeGuidePage({
                 </div>
               )}
               <form action="/api/waitlist" method="POST" className="flex gap-2">
+                <input type="hidden" name="next" value="/free-guide" />
                 <input
                   type="email"
                   name="email"
@@ -369,6 +370,7 @@ export default function FreeGuidePage({
 
           <div className="max-w-md mx-auto mb-8">
             <form action="/api/waitlist" method="POST" className="flex gap-2">
+              <input type="hidden" name="next" value="/free-guide" />
               <input
                 type="email"
                 name="email"

--- a/app/starter-kit/page.tsx
+++ b/app/starter-kit/page.tsx
@@ -103,6 +103,7 @@ export default async function StarterKitPage({
             </div>
           )}
           <form action="/api/waitlist" method="POST" className="flex gap-2">
+            <input type="hidden" name="next" value="/starter-kit" />
             <input
               type="email"
               name="email"
@@ -214,6 +215,7 @@ export default async function StarterKitPage({
         <p className="text-neutral-400 mb-8">Free. In your inbox immediately.</p>
         <div className="max-w-md mx-auto">
           <form action="/api/waitlist" method="POST" className="flex gap-2">
+            <input type="hidden" name="next" value="/starter-kit" />
             <input
               type="email"
               name="email"

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -47,6 +47,11 @@ export default function TestimonialsPage() {
       setStatus("error");
       return;
     }
+    if (!form.consentPublic) {
+      setErrorMsg("Please consent to public display before submitting.");
+      setStatus("error");
+      return;
+    }
     setStatus("submitting");
     setErrorMsg("");
 

--- a/lib/testimonials-db.ts
+++ b/lib/testimonials-db.ts
@@ -21,11 +21,49 @@ export async function initTestimonialsTable() {
       company TEXT,
       testimonial TEXT NOT NULL,
       avatar_url TEXT,
+      rating INTEGER,
+      consent INTEGER NOT NULL DEFAULT 0,
       featured INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL
     )
   `);
+  // Existing prod tables predate rating/consent; add them if missing. SQLite
+  // throws on a duplicate column — expected after the first run, so swallow.
+  for (const alter of [
+    "ALTER TABLE testimonials ADD COLUMN rating INTEGER",
+    "ALTER TABLE testimonials ADD COLUMN consent INTEGER NOT NULL DEFAULT 0",
+  ]) {
+    try {
+      await client.execute(alter);
+    } catch {
+      // column already present
+    }
+  }
+  // PII is isolated here so it can never leak through a select() on the public
+  // testimonials table. Email is stored for admin follow-up; never rendered.
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS testimonial_contacts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      testimonial_id INTEGER NOT NULL,
+      email TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
   initialized = true;
+}
+
+// Record a submitter's contact email in the PII-isolated table. No-op for a
+// blank email. Never logs the address.
+export async function recordSubmitterEmail(
+  testimonialId: number,
+  email: string
+): Promise<void> {
+  const clean = email.trim().toLowerCase().slice(0, 254);
+  if (!clean || !clean.includes("@")) return;
+  await client.execute({
+    sql: "INSERT INTO testimonial_contacts (testimonial_id, email, created_at) VALUES (?, ?, ?)",
+    args: [testimonialId, clean, Date.now()],
+  });
 }
 
 // Placeholder seeding was removed on purpose: it inserted six invented

--- a/lib/testimonials-schema.ts
+++ b/lib/testimonials-schema.ts
@@ -7,11 +7,19 @@ export const testimonials = sqliteTable("testimonials", {
   company: text("company"),
   testimonial: text("testimonial").notNull(),
   avatarUrl: text("avatar_url"),
+  rating: integer("rating"),
+  // Whether the submitter consented to public display. Non-PII; a submit-time
+  // gate for public submissions.
+  consent: integer("consent", { mode: "boolean" }).notNull().default(false),
   featured: integer("featured", { mode: "boolean" }).notNull().default(false),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+// Submitter contact email is PII and lives in a SEPARATE table so it can never
+// leak through a `select()` on the public `testimonials` table (which is
+// rendered publicly). Stored for admin follow-up only; never rendered or logged.
 
 export type Testimonial = typeof testimonials.$inferSelect;
 export type NewTestimonial = typeof testimonials.$inferInsert;


### PR DESCRIPTION
Fixes #99.

## Part 1 — /testimonials form was 401 for every visitor
The form POSTed to an **admin-only** endpoint, so real visitors always got 401.

- **Public submission path:** an unauthenticated POST now creates an **unpublished** row (`featured=0`), pending admin review. Admins can still create featured rows directly.
- **Field alignment:** the form sends `testimonialText`/`consentPublic`; the admin client sends `testimonial`/`featured`. The API accepts both. Public submissions require consent; rating validated 1–5.
- **Abuse protection:** same-origin guard (`Origin`/`Referer` host vs the request host — scripts can't forge those) + a light in-memory rate limit, mirroring PR #107's analytics-track pattern. No new deps.
- **PII:** the optional submitter email is stored in a **separate `testimonial_contacts` table** so it can never leak through a `select()` on the public `testimonials` table (which is rendered publicly). It is never rendered or logged. New `rating`/`consent` columns added via the CREATE + idempotent ALTER pattern.

## Part 2 — lead-magnet success UI was dead code
`/free-guide` and `/starter-kit` forms POST `/api/waitlist`, which always redirected to `/?success=joined` — so their own `showSuccess` states never rendered.

- Each form now passes a hidden `next` (its own path). The waitlist route redirects there for **both** success and error, **only** if it's a same-origin relative path.
- **Open-redirect guard:** `sanitizeReturnPath` accepts a single-leading-`/` relative path only; `//evil.com`, schemes, and query-bearing values fall back to the homepage. Homepage forms (no `next`) keep the old `/?success=joined` behavior.

## Verification (live-probed, not just built)
- `pnpm build` green.
- Testimonials: scripted no-Origin POST → **403**; missing consent → **400**; valid public submission → **201** with `featured:false` and **no email in the response**; email confirmed stored in `testimonial_contacts`, absent from the `testimonials` table.
- Waitlist: `next=/free-guide` → `/free-guide?success=joined`; `next=//evil.com` → blocked (falls back to `/?success=joined`); no `next` → `/?success=joined`; invalid email + `next=/starter-kit` → `/starter-kit?error=invalid_email`.
- Tests: 10 new (pure `validateTestimonialSubmission`, the 403 gate, waitlist next-redirect + open-redirect guard) — all pass. The 4 remaining suite failures are pre-existing baseline (lib/email ×3 and the waitlist `duplicate email` mock, which rejects the CREATE-TABLE call — confirmed failing on origin/main), not introduced here.

## CEO to E2E-verify in production (no prod DB creds here)
1. Submit a real testimonial at `/testimonials` → 201, row appears **unpublished** in admin; confirm the email is in `testimonial_contacts` and **not** in `testimonials`.
2. On first deploy, `initTestimonialsTable` adds `rating`/`consent` and creates `testimonial_contacts` (idempotent ALTERs).
3. Sign up via `/free-guide` and `/starter-kit` → each shows its **own** success state (returns to its own URL), and confirm `//evil.com` in `next` cannot redirect off-site.

Substantive code → **code-reviewer gate**.