### PR TITLE
Rate-limiter follow-ups from PR #110 review (part of #111)

### DIFF
--- a/app/api/analytics/track/__tests__/route.test.ts
+++ b/app/api/analytics/track/__tests__/route.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import {
   sameOriginAllowed,
   isRateLimited,
   clientIp,
+  resetRateLimiterForTest,
   RATE_MAX,
   RATE_WINDOW_MS,
+  MAX_TRACKED_KEYS,
 } from "../route";
 
 describe("analytics/track request guards", () => {
+  // Reset the module-level map before each test so they don't leak state into
+  // one another (and don't need to invent distinct keys per test).
+  beforeEach(() => {
+    resetRateLimiterForTest();
+  });
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -38,9 +45,9 @@ describe("analytics/track request guards", () => {
     it("prefers the platform-set x-real-ip header", () => {
       expect(clientIp("1.1.1.1, 2.2.2.2", "9.9.9.9")).toBe("9.9.9.9");
     });
-    it("uses the RIGHTMOST x-forwarded-for entry, defeating leftmost spoofing", () => {
-      // An attacker prepends fake entries; the platform appends the real IP last.
-      expect(clientIp("fake1, fake2, 203.0.113.7", null)).toBe("203.0.113.7");
+    it("takes the RIGHTMOST (proxy-appended) x-forwarded-for entry", () => {
+      // Rightmost is the hop a trusted appending proxy added (see clientIp docs).
+      expect(clientIp("hop1, hop2, 203.0.113.7", null)).toBe("203.0.113.7");
     });
     it("handles a single-value x-forwarded-for", () => {
       expect(clientIp("203.0.113.7", null)).toBe("203.0.113.7");
@@ -66,6 +73,24 @@ describe("analytics/track request guards", () => {
       expect(isRateLimited(key)).toBe(true); // over the cap now
       vi.advanceTimersByTime(RATE_WINDOW_MS + 1);
       expect(isRateLimited(key)).toBe(false); // fresh window
+    });
+
+    // #110 headline behavior: the bounded map evicts oldest-inserted entries
+    // under a unique-key flood, so a formerly-blocked oldest key comes back
+    // "fresh" once evicted.
+    it("evicts the oldest-inserted key when flooded past MAX_TRACKED_KEYS", () => {
+      const victim = "oldest-victim";
+      // Push the victim over the limit — while its entry survives it stays blocked.
+      for (let i = 0; i < RATE_MAX + 1; i++) isRateLimited(victim);
+      expect(isRateLimited(victim)).toBe(true);
+
+      // Flood > MAX_TRACKED_KEYS fresh unique keys in the same window. Eviction
+      // removes oldest-inserted entries — the victim (inserted first) among them.
+      for (let i = 0; i <= MAX_TRACKED_KEYS; i++) isRateLimited(`flood-${i}`);
+
+      // Evicted → treated as a brand-new key again (allowed). If eviction had
+      // NOT happened, the victim's entry would still be over the cap (blocked).
+      expect(isRateLimited(victim)).toBe(false);
     });
   });
 });

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -48,18 +48,26 @@ const rateHits = new Map<string, { count: number; resetAt: number }>();
 // Hard ceiling on distinct tracked keys. The expired-sweep alone can't bound a
 // flood of unique keys within one window (none are expired yet), so past this
 // size we also evict the oldest-inserted entries — memory stays bounded.
-const MAX_TRACKED_KEYS = 10_000;
+export const MAX_TRACKED_KEYS = 10_000;
 export function isRateLimited(key: string): boolean {
   const now = Date.now();
   const entry = rateHits.get(key);
   if (!entry || now > entry.resetAt) {
     rateHits.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
     if (rateHits.size > MAX_TRACKED_KEYS) {
-      // 1) drop expired entries
-      for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
-      // 2) if still over the ceiling (a live flood of unique keys), evict the
-      //    oldest-inserted entries until back under the cap. Map preserves
-      //    insertion order and deleting during iteration is safe.
+      // Perf: entries share one fixed window, so the oldest-inserted entry is
+      // the earliest to expire. If it's still fresh, no entry is expired —
+      // skip the O(n) expired-sweep and go straight to eviction. This is the
+      // common case under a sustained unique-key flood. (A key refreshed
+      // in-place can sit older-in-order with a later expiry; then we simply
+      // evict it as "oldest", which still bounds memory.)
+      const oldest = rateHits.values().next().value;
+      if (oldest && now > oldest.resetAt) {
+        for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
+      }
+      // If still over the ceiling (a live flood of unique keys), evict the
+      // oldest-inserted entries until back under the cap. Map preserves
+      // insertion order and deleting during iteration is safe.
       if (rateHits.size > MAX_TRACKED_KEYS) {
         let toEvict = rateHits.size - MAX_TRACKED_KEYS;
         for (const k of rateHits.keys()) {
@@ -72,6 +80,12 @@ export function isRateLimited(key: string): boolean {
   }
   entry.count += 1;
   return entry.count > RATE_MAX;
+}
+
+// Test-only: clear the module-level rate-limit map so tests don't leak state
+// into one another.
+export function resetRateLimiterForTest(): void {
+  rateHits.clear();
 }
 
 // Same-origin guard: real page-view beacons carry an Origin (POST) or a
@@ -105,10 +119,17 @@ function isSameOrigin(request: NextRequest): boolean {
   );
 }
 
-// The trustworthy client IP on Vercel is the platform-set x-real-ip, or the
-// RIGHTMOST x-forwarded-for entry (the platform appends the real client IP;
-// leftmost entries are client-controlled and spoofable). Using the rightmost
-// value stops an attacker rotating fake leftmost IPs to evade the cap.
+// Client IP for rate-limit keying. On Vercel, x-real-ip is the platform-set
+// client IP and is the primary, trustworthy source. The x-forwarded-for
+// fallback takes the RIGHTMOST entry — but note WHY: on Vercel, XFF is
+// effectively single-valued (the platform overwrites it and drops any
+// client-supplied value), so leftmost vs rightmost is moot there; there is no
+// "attacker rotating fake leftmost IPs" vector on Vercel. Rightmost is the
+// correct choice only on a stack that APPENDS the real client IP to a
+// client-supplied XFF via a trusted proxy. Do NOT over-trust XFF as
+// unspoofable: without such a proxy it is fully client-controlled, and under a
+// Vercel Enterprise trusted-proxy config XFF can carry multiple hops where the
+// rightmost is your proxy, not the true client — revisit this if that's enabled.
 export function clientIp(
   xForwardedFor: string | null,
   xRealIp: string | null

--- a/app/api/testimonials/__tests__/route.test.ts
+++ b/app/api/testimonials/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import {
   POST,
@@ -6,8 +6,10 @@ import {
   sameOriginAllowed,
   isRateLimited,
   clientIp,
+  resetRateLimiterForTest,
   RATE_MAX,
   RATE_WINDOW_MS,
+  MAX_TRACKED_KEYS,
 } from '../route';
 
 // The route also touches the DB on the (untestable-in-unit) same-origin-pass
@@ -92,6 +94,10 @@ describe('POST /api/testimonials same-origin gate', () => {
 
 // --- Reusable request guards (same-origin, client IP, rate limit) ---
 describe('testimonials request guards', () => {
+  // Reset the module-level map before each test so they don't leak state.
+  beforeEach(() => {
+    resetRateLimiterForTest();
+  });
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -115,8 +121,8 @@ describe('testimonials request guards', () => {
     it('prefers the platform x-real-ip header', () => {
       expect(clientIp('1.1.1.1, 2.2.2.2', '9.9.9.9')).toBe('9.9.9.9');
     });
-    it('uses the RIGHTMOST x-forwarded-for entry (defeats leftmost spoofing)', () => {
-      expect(clientIp('fake1, fake2, 203.0.113.7', null)).toBe('203.0.113.7');
+    it('takes the RIGHTMOST (proxy-appended) x-forwarded-for entry', () => {
+      expect(clientIp('hop1, hop2, 203.0.113.7', null)).toBe('203.0.113.7');
     });
     it('falls back to "unknown" with no IP headers', () => {
       expect(clientIp(null, null)).toBe('unknown');
@@ -136,6 +142,19 @@ describe('testimonials request guards', () => {
       expect(isRateLimited(key)).toBe(true);
       vi.advanceTimersByTime(RATE_WINDOW_MS + 1);
       expect(isRateLimited(key)).toBe(false);
+    });
+
+    // #110 headline behavior: the bounded map evicts oldest-inserted entries
+    // under a unique-key flood, so a formerly-blocked oldest key comes back
+    // "fresh" once evicted.
+    it('evicts the oldest-inserted key when flooded past MAX_TRACKED_KEYS', () => {
+      const victim = 'oldest-victim';
+      for (let i = 0; i < RATE_MAX + 1; i++) isRateLimited(victim);
+      expect(isRateLimited(victim)).toBe(true); // blocked while its entry exists
+
+      for (let i = 0; i <= MAX_TRACKED_KEYS; i++) isRateLimited(`flood-${i}`);
+
+      expect(isRateLimited(victim)).toBe(false); // evicted -> fresh again
     });
   });
 });

--- a/app/api/testimonials/route.ts
+++ b/app/api/testimonials/route.ts
@@ -19,18 +19,26 @@ const rateHits = new Map<string, { count: number; resetAt: number }>();
 // Hard ceiling on distinct tracked keys. The expired-sweep alone can't bound a
 // flood of unique keys within one window (none are expired yet), so past this
 // size we also evict the oldest-inserted entries — memory stays bounded.
-const MAX_TRACKED_KEYS = 10_000;
+export const MAX_TRACKED_KEYS = 10_000;
 export function isRateLimited(key: string): boolean {
   const now = Date.now();
   const entry = rateHits.get(key);
   if (!entry || now > entry.resetAt) {
     rateHits.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
     if (rateHits.size > MAX_TRACKED_KEYS) {
-      // 1) drop expired entries
-      for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
-      // 2) if still over the ceiling (a live flood of unique keys), evict the
-      //    oldest-inserted entries until back under the cap. Map preserves
-      //    insertion order and deleting during iteration is safe.
+      // Perf: entries share one fixed window, so the oldest-inserted entry is
+      // the earliest to expire. If it's still fresh, no entry is expired —
+      // skip the O(n) expired-sweep and go straight to eviction. This is the
+      // common case under a sustained unique-key flood. (A key refreshed
+      // in-place can sit older-in-order with a later expiry; then we simply
+      // evict it as "oldest", which still bounds memory.)
+      const oldest = rateHits.values().next().value;
+      if (oldest && now > oldest.resetAt) {
+        for (const [k, v] of rateHits) if (now > v.resetAt) rateHits.delete(k);
+      }
+      // If still over the ceiling (a live flood of unique keys), evict the
+      // oldest-inserted entries until back under the cap. Map preserves
+      // insertion order and deleting during iteration is safe.
       if (rateHits.size > MAX_TRACKED_KEYS) {
         let toEvict = rateHits.size - MAX_TRACKED_KEYS;
         for (const k of rateHits.keys()) {
@@ -45,10 +53,23 @@ export function isRateLimited(key: string): boolean {
   return entry.count > RATE_MAX;
 }
 
-// The trustworthy client IP on Vercel is the platform-set x-real-ip, or the
-// RIGHTMOST x-forwarded-for entry (the platform appends the real client IP;
-// leftmost entries are client-controlled and spoofable). Using the rightmost
-// value stops an attacker rotating fake leftmost IPs to evade the cap.
+// Test-only: clear the module-level rate-limit map so tests don't leak state
+// into one another.
+export function resetRateLimiterForTest(): void {
+  rateHits.clear();
+}
+
+// Client IP for rate-limit keying. On Vercel, x-real-ip is the platform-set
+// client IP and is the primary, trustworthy source. The x-forwarded-for
+// fallback takes the RIGHTMOST entry — but note WHY: on Vercel, XFF is
+// effectively single-valued (the platform overwrites it and drops any
+// client-supplied value), so leftmost vs rightmost is moot there; there is no
+// "attacker rotating fake leftmost IPs" vector on Vercel. Rightmost is the
+// correct choice only on a stack that APPENDS the real client IP to a
+// client-supplied XFF via a trusted proxy. Do NOT over-trust XFF as
+// unspoofable: without such a proxy it is fully client-controlled, and under a
+// Vercel Enterprise trusted-proxy config XFF can carry multiple hops where the
+// rightmost is your proxy, not the true client — revisit this if that's enabled.
 export function clientIp(
   xForwardedFor: string | null,
   xRealIp: string | null


### PR DESCRIPTION
**Part of #111** — the four non-blocking nits the reviewer flagged on PR #110. Small, focused, no new dependencies. Applied to **both** `/api/analytics/track` and `/api/testimonials` (the rate-limit code is duplicated per-route — kept in place per the task's small-focused scope; a future DRY extraction into a shared `lib/rate-limit.ts` is a reasonable follow-up if the reviewer prefers).

### 1. Cap/eviction regression test (headline #110 behavior)
Flood `> MAX_TRACKED_KEYS` unique keys within one window and assert a formerly-**blocked** oldest key is evicted and treated as **fresh** again. This was the only new #110 logic without a regression test.

### 2. Corrected the client-IP rationale (comment only)
The old comment overclaimed leftmost XFF as "spoofable" and defended against "attackers rotating fake leftmost IPs." On Vercel that vector doesn't exist — the platform overwrites `x-forwarded-for` and drops client-supplied IPs, so XFF is effectively single-valued. The comment now explains that rightmost-XFF is only meaningful when a **trusted proxy appends** the real client IP, that under a **Vercel Enterprise trusted-proxy** config the rightmost could be your proxy (not the true client), and that XFF should not be over-trusted as unspoofable. `x-real-ip` stays primary. Test names updated to match (no "spoofing" framing).

### 3. Perf: short-circuit the expired-sweep under a flood
The sweep was O(n) (~10k) per insert once over the cap, finding ~0 expired during a sustained unique-key flood. Now peek the oldest-inserted entry (O(1)); since entries share one fixed window the oldest expires first, so if it's still fresh we skip the sweep and go straight to bounded eviction. Falls back to the full sweep when the oldest actually is expired. Simple, no new state.

### 4. Test hygiene
Added `resetRateLimiterForTest()` (clears the module-level map) and a `beforeEach` reset in the rate-limit test blocks, so tests no longer leak state or rely on inventing distinct keys.

## Verification
- `pnpm build` green.
- Rate-limit route tests: 29 pass (incl. the 2 new cap tests). Full suite: 80 pass; the only 4 failures are the pre-existing baseline (`lib/email` ×3 and the waitlist `duplicate email` mock — both fail on origin/main, untouched here).

The durable/Redis rate-limit store stays flagged in **#108** for the human. Substantive code → **code-reviewer gate**.