### PR TITLE
Scaffold: correct Orca platform claim — macOS + Linux, not macOS-only (part of #102)

### DIFF
--- a/examples/agent-team-scaffold/docs/SCALING.md
+++ b/examples/agent-team-scaffold/docs/SCALING.md
@@ -53,6 +53,7 @@ many isolated worktree seats. **What stays the same:** the briefs, the review
 gates, the operating rules, the definition of done. That constancy is the whole
 design: you scale the runtime, not the team.
 
-> Note: Orca is a desktop app (currently macOS). The native path (Levels 0–2) is
+> Note: Orca is a desktop app (macOS + Linux), with free mobile companion apps.
+> The native path (Levels 0–2) is
 > cross-platform and needs only Claude Code + an API key, so nothing blocks you
 > from starting today and graduating to the fleet later.

--- a/examples/agent-team-scaffold/scripts/orca-bootstrap.sh
+++ b/examples/agent-team-scaffold/scripts/orca-bootstrap.sh
@@ -2,7 +2,7 @@
 # orca-bootstrap.sh — (Level 3) recreate the 7-seat parallel fleet in Orca.
 #
 # Prerequisites:
-#   - Orca installed (https://www.onorca.dev — free, MIT; desktop app, macOS)
+#   - Orca installed (https://www.onorca.dev — free, MIT; desktop, macOS + Linux)
 #   - Claude Code installed and authenticated
 #   - Run from the root of the repo you want the fleet to work on
 #


### PR DESCRIPTION
Fixes the factual inaccuracy found in LICENSING_NOTES.md §1 (merged in #116): the scaffold said Orca is macOS-only; verified reality is macOS + Linux (AUR) with free mobile companion apps. Two spots corrected (SCALING.md note, orca-bootstrap.sh header comment) — docs/comment text only, no script logic. Grep sweep found no other macOS-only phrasing in the scaffold.

Fast-track lane (factual docs correction, CEO-reviewed). Part of #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)