### PR TITLE
Scaffold hardening: setup.sh overwrite guard for all files + orca CLI flag fixes (fixes #118)

### DIFF
--- a/examples/agent-team-scaffold/scripts/dispatch.sh
+++ b/examples/agent-team-scaffold/scripts/dispatch.sh
@@ -31,10 +31,13 @@ Seats are persistent workers in isolated worktrees (see orca-bootstrap.sh).
 Dispatch a task to a seat and inject it:
 
   orca orchestration task-create \
-    --title "<short title>" \
-    --body "<the scoped brief for the specialist>"
+    --task-title "<short title>" \
+    --spec "<the scoped brief for the specialist>"
 
-  orca orchestration dispatch --inject --to <seat> --task <task-id>
+  orca orchestration dispatch --inject --to <seat-terminal-handle> --task <task-id>
+
+(`--to` takes the seat's terminal handle: read it from `orca worktree create
+--json` output when bootstrapping, or find it later with `orca terminal list`.)
 
 The seat works on its own branch and reports back with `worker_done`. The CEO
 seat routes the result to the reviewer seat, then merges + verifies.

--- a/examples/agent-team-scaffold/scripts/orca-bootstrap.sh
+++ b/examples/agent-team-scaffold/scripts/orca-bootstrap.sh
@@ -57,6 +57,6 @@ fi
 cat <<'EOF'
 
 Once seats exist, dispatch from the CEO seat (see scripts/dispatch.sh):
-  orca orchestration task-create --title "..." --body "<scoped brief>"
-  orca orchestration dispatch --inject --to <seat> --task <task-id>
+  orca orchestration task-create --task-title "..." --spec "<scoped brief>"
+  orca orchestration dispatch --inject --to <seat-terminal-handle> --task <task-id>
 EOF

--- a/examples/agent-team-scaffold/scripts/setup.sh
+++ b/examples/agent-team-scaffold/scripts/setup.sh
@@ -6,8 +6,8 @@
 #
 # Copies the team definition (.claude/agents, roles/) and the operating docs
 # (CLAUDE.md, OPERATIONS.md, FACTS.md, docs/) into your repo so a plain
-# `claude` session becomes a coordinated team. Idempotent; won't clobber an
-# existing CLAUDE.md unless you pass --force.
+# `claude` session becomes a coordinated team. Idempotent; won't clobber any
+# existing file (including briefs you've customized) unless you pass --force.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -25,28 +25,33 @@ fi
 
 echo "Installing agent-team scaffold into: $DEST"
 
-# 1) Team definition — always safe to (re)install.
-mkdir -p "$DEST/.claude/agents" "$DEST/roles" "$DEST/docs"
-cp "$HERE"/.claude/agents/*.md "$DEST/.claude/agents/"
-cp "$HERE"/roles/*.md          "$DEST/roles/"
-cp "$HERE"/docs/*.md           "$DEST/docs/"
-echo "  ✓ .claude/agents/  (6 specialist subagents)"
-echo "  ✓ roles/ceo.md"
-echo "  ✓ docs/  (github interaction model, scaling)"
-
-# 2) Operating docs — don't clobber existing files without --force.
-install_doc() {
-  local name="$1"
-  if [[ -f "$DEST/$name" && "$FORCE" != "--force" ]]; then
-    echo "  • $name already exists — skipped (pass --force to overwrite)"
+# Don't clobber existing files (e.g. briefs the buyer customized) without --force.
+install_file() {
+  local src="$1" rel="$2"
+  if [[ -f "$DEST/$rel" && "$FORCE" != "--force" ]]; then
+    echo "  • $rel already exists — skipped (pass --force to overwrite)"
   else
-    cp "$HERE/$name" "$DEST/$name"
-    echo "  ✓ $name"
+    cp "$src" "$DEST/$rel"
+    echo "  ✓ $rel"
   fi
 }
-install_doc OPERATIONS.md
-install_doc FACTS.md
-install_doc CLAUDE.md
+
+# 1) Team definition — 6 specialist subagents, CEO brief, docs.
+mkdir -p "$DEST/.claude/agents" "$DEST/roles" "$DEST/docs"
+for f in "$HERE"/.claude/agents/*.md; do
+  install_file "$f" ".claude/agents/$(basename "$f")"
+done
+for f in "$HERE"/roles/*.md; do
+  install_file "$f" "roles/$(basename "$f")"
+done
+for f in "$HERE"/docs/*.md; do
+  install_file "$f" "docs/$(basename "$f")"
+done
+
+# 2) Operating docs — same rule.
+install_file "$HERE/OPERATIONS.md" OPERATIONS.md
+install_file "$HERE/FACTS.md"      FACTS.md
+install_file "$HERE/CLAUDE.md"     CLAUDE.md
 
 # 3) Prerequisite check + first-run instructions.
 echo


### PR DESCRIPTION
## Summary
Follow-ups from the PR #113 code review (tracked in #118):

- **setup.sh**: the `--force` overwrite guard now covers *every* installed file — `.claude/agents/*`, `roles/*`, and `docs/*` — via a shared `install_file` helper, not just the three top-level operating docs. A buyer's customized brief now survives a re-run of setup.sh; `--force` restores defaults.
- **orca CLI flag drift** (found by smoke-testing the real CLI): `task-create` takes `--task-title`/`--spec` (not `--title`/`--body`), and `dispatch --to` takes a terminal handle. Fixed the printed commands in `orca-bootstrap.sh` and the docs in `dispatch.sh`.

## Verification
- Functionally verified in a scratchpad that a customized brief survives re-install and that `--force` overwrites it.
- `bash -n` passes on all three scripts; `pnpm build` green.
- Scope: `examples/agent-team-scaffold/scripts/` only — no site behavior change, no protected files.

Fixes #118. Part of #102 (Agent Operations Pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)