### PR TITLE
Scaffold setup.sh polish: nullglob on copy loops + directory-collision guard (fixes #120)

### DIFF
--- a/examples/agent-team-scaffold/scripts/setup.sh
+++ b/examples/agent-team-scaffold/scripts/setup.sh
@@ -28,7 +28,10 @@ echo "Installing agent-team scaffold into: $DEST"
 # Don't clobber existing files (e.g. briefs the buyer customized) without --force.
 install_file() {
   local src="$1" rel="$2"
-  if [[ -f "$DEST/$rel" && "$FORCE" != "--force" ]]; then
+  if [[ -d "$DEST/$rel" ]]; then
+    echo "  ! $rel exists as a DIRECTORY in the destination — skipped." >&2
+    echo "    Move it aside and re-run to install this file." >&2
+  elif [[ -e "$DEST/$rel" && "$FORCE" != "--force" ]]; then
     echo "  • $rel already exists — skipped (pass --force to overwrite)"
   else
     cp "$src" "$DEST/$rel"
@@ -37,7 +40,10 @@ install_file() {
 }
 
 # 1) Team definition — 6 specialist subagents, CEO brief, docs.
+# nullglob so an empty source dir skips its loop instead of passing a literal
+# glob to cp; restored right after the loops.
 mkdir -p "$DEST/.claude/agents" "$DEST/roles" "$DEST/docs"
+shopt -s nullglob
 for f in "$HERE"/.claude/agents/*.md; do
   install_file "$f" ".claude/agents/$(basename "$f")"
 done
@@ -47,6 +53,7 @@ done
 for f in "$HERE"/docs/*.md; do
   install_file "$f" "docs/$(basename "$f")"
 done
+shopt -u nullglob
 
 # 2) Operating docs — same rule.
 install_file "$HERE/OPERATIONS.md" OPERATIONS.md


### PR DESCRIPTION
Implements the two non-blocking nits from the PR #119 review, filed as #120:

1. **nullglob** — `shopt -s nullglob` scoped around the three copy loops (restored right after), so an empty source dir skips its loop instead of passing a literal glob to `cp`.
2. **dest-is-directory guard** — `install_file` now checks `-d` first and, on a directory collision, prints a clear error to stderr and skips (checked before `--force`, since `cp` onto a directory would silently drop the file inside it). Plain-file skip/`--force` semantics unchanged.

Verified by the engineer with `bash -n` plus a scratch-dir matrix: fresh install (12 files), re-run without `--force` (12 skips), `--force` overwrite, dest-dir collision (error + skip, exit 0), and an emptied `docs/` source dir (no literal-glob error).

Only `examples/agent-team-scaffold/scripts/setup.sh` is touched. Part of #102.

fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)