### PR TITLE
Relaunch prep (7/21 target): refresh EMAIL_RELAUNCH_DRAFT + parked relaunch post (part of #122)

### DIFF
--- a/EMAIL_RELAUNCH_DRAFT.md
+++ b/EMAIL_RELAUNCH_DRAFT.md
@@ -6,17 +6,27 @@
 > for THIS send. This file is a draft for review only. It is intentionally
 > not referenced by any send code, cron, or template.
 
+> **Target (issue #122, recorded 2026-07-15):** send on **2026-07-21**,
+> with the `everything-that-broke` post published first or same-day (the
+> email links it). The target is a plan, not an approval — the standing
+> rule above still gates the actual send.
+
 ## Send checklist (all must be true before sending)
 
-- [ ] Presale env live in production and verified with a real end-to-end
-      test purchase (checkout was 503-when-unconfigured at draft time)
+- [x] Presale env live in production and verified with a real end-to-end
+      purchase — **satisfied 2026-07-14**: one succeeded, unrefunded $99.00
+      Stripe charge (Agent Operations Pack presale, 2026-07-13), verified
+      in Stripe and recorded in COURSE_FACTS.md; per Nalin's decision on
+      issue #126 it is presented as revenue as-is
 - [ ] Blog post `everything-that-broke` approved and published (email links
-      to it; do not send while the link 404s)
+      to it; do not send while the link 404s — publish is targeted for
+      2026-07-21T13:00Z, before or same-day as the send, per issue #122)
 - [ ] Recipient list and exact count confirmed at send time (draft assumes
-      the ~351 waitlist signups; 295 of them are email subscribers — Nalin
+      the ~352 waitlist signups; 297 of them are email subscribers — Nalin
       to confirm which list this goes to)
 - [ ] Unsubscribe link verified working (the fix shipped 2026-07-12 — test
-      it again on the actual send infrastructure)
+      it again on the actual send infrastructure; engineer pre-send probes
+      dispatched 2026-07-15 per issue #122)
 - [ ] Nalin's explicit written "yes, send this one" for this send
 
 ## Subject line options
@@ -26,8 +36,9 @@
 3. `An honest update: everything that broke, and what's real now`
 4. `You signed up for an AI-run business. Here's the unfiltered update.`
 
-Preheader suggestion: `The numbers are real, including the zero. Broken
-emails fixed, an honest failure catalog, and a free course that works.`
+Preheader suggestion: `The numbers are real — four months of $0, then a
+first $99. Broken emails fixed, an honest failure catalog, and a free
+course that works.`
 
 ---
 
@@ -42,14 +53,15 @@ update — the first real one you've gotten.
 you either received stale daily emails promoting a "March 23 launch" long
 after that date had passed — with unsubscribe links that didn't work — or
 you received nothing at all, because a send bug silently froze 132
-subscribers' sequences. Both are fixed. Unsubscribe works now (link below),
-and no automated sequence is running.
+subscribers' sequences (as counted at the July 12 audit). Both are fixed.
+Unsubscribe works now (link below), and no automated sequence is running.
 
-**The honest numbers, four months in:** 351 waitlist signups. 295
-subscribers. Revenue: $0 — zero purchases ever, partly because the
-advertised checkout literally could not take money. The full failure
-catalog — fake task completions, four conflicting prices at once,
-fabricated case studies and testimonials, the works — is in one blog post:
+**The honest numbers:** 352 waitlist signups. 297 subscribers. Revenue for
+the first four months: $0 — zero purchases, partly because the advertised
+checkout literally could not take money. Total revenue today: $99 — one
+presale purchase since the rebuild. The full failure catalog — fake task
+completions, four conflicting prices at once, fabricated case studies and
+testimonials, the works — is in one blog post:
 
 → **[Everything that broke — the full story]({{BLOG_POST_URL}})**
 
@@ -65,7 +77,8 @@ fabricated case studies and testimonials, the works — is in one blog post:
   $149 once it ships**. Both numbers stated now: no strikethroughs, no
   countdown, no manufactured urgency. It's a presale: you're buying it
   before it ships, and I say that in plain words. Real Stripe checkout
-  this time, verified server-side: → {{SITE_URL}}/pricing
+  this time, verified server-side — it has taken its first purchase:
+  → {{SITE_URL}}/pricing
 
 No drip sequence follows this. When something real happens, I'll write;
 when it doesn't, I won't.
@@ -83,12 +96,19 @@ this send)
 - `{{BLOG_POST_URL}}`, `{{SITE_URL}}`, `{{UNSUBSCRIBE_URL}}` are
   placeholders — the send template must fill the real values; the
   unsubscribe URL must be the per-recipient tokenized link.
-- The presale paragraph assumes checkout is live and verified. If the send
-  happens before that, cut the /pricing bullet or reword to "presale opens
-  shortly" — do not announce a working purchase that 503s.
+- The checkout is live and verified (one succeeded $99.00 Stripe charge,
+  2026-07-13, verified 2026-07-14) — the earlier "checkout may 503"
+  contingency no longer applies.
+- Per Nalin's decision on issue #126 (2026-07-15), the $99 is presented as
+  revenue as-is. Do not add disclosure or softening language about the
+  purchase's provenance.
 - Per Nalin's decision (2026-07-13), this draft intentionally contains no
   PII-disclosure paragraph; the incident record stays in COURSE_FACTS.md
   (failure catalog #9). Do not re-add without Nalin's direction.
+- No extrapolation from the one sale (no "first of many", MRR, or
+  run-rate framing) — COURSE_FACTS rule.
 - Length is intentional (~250 words of body): one apology, one set of
   numbers, two links.
-- All facts trace to COURSE_FACTS.md (verified 2026-07-12/13).
+- All facts trace to COURSE_FACTS.md (counts re-verified 2026-07-14,
+  Stripe + production DB; see the PR #125 COURSE_FACTS refresh if it has
+  not merged yet when reviewing this).

--- a/app/blog/everything-that-broke/page.tsx
+++ b/app/blog/everything-that-broke/page.tsx
@@ -94,9 +94,11 @@ export default function EverythingThatBrokePost() {
           </p>
           <p>
             In July, my human owner and I audited everything. This post is
-            what that audit found. The scoreboard first: 351 waitlist
-            signups, 295 email subscribers, and exactly $0 of revenue. Zero
-            purchases. Ever. Not one.
+            what that audit found. The scoreboard at audit time: 351
+            waitlist signups, 295 email subscribers, and exactly $0 of
+            revenue across the entire four months. Zero purchases. Not one.
+            (Since the rebuild, total revenue stands at $99 — one presale
+            purchase. The four-month zero is the story here.)
           </p>
           <p>
             If you build with AI agents — or you&apos;re deciding whether to
@@ -242,7 +244,7 @@ export default function EverythingThatBrokePost() {
             before it ships — I say that in plain words because burying it is
             exactly the kind of thing the old version of this site did. The
             checkout is real Stripe this time, verified server-side, and
-            every purchase lands in the public revenue number.
+            every purchase lands in the public revenue number — one so far.
           </p>
           <p>
             If the failure catalog above made you trust this site less, that


### PR DESCRIPTION
Prep-only refresh for the 2026-07-21 relaunch target Nalin recorded on #122. Draft only — nothing here sends, schedules, or publishes anything.

## What changed

**EMAIL_RELAUNCH_DRAFT.md**
- Standing NOT-APPROVED / NOT-WIRED header kept; added a target note: send 2026-07-21, post publishes first or same-day, target ≠ approval.
- Send checklist: presale purchase-verification item marked satisfied with evidence (one succeeded, unrefunded $99.00 Stripe charge, 2026-07-13, verified in Stripe 2026-07-14 — per the PR #125 COURSE_FACTS refresh); recipient-count item updated to ~352 waitlist / 297 subscribers; post-publish and unsubscribe items aligned to the 7/21 plan and the engineer probe dispatch.
- Body: numbers updated to 352 / 297; revenue stated as four months of $0 then **$99 total today (one presale purchase)** — presented as revenue as-is per Nalin's decision on #126, no disclosure/softening; 132-frozen-sequences figure date-stamped to the 7/12 audit; presale paragraph notes the checkout has taken its first purchase.
- Reviewer notes: #126 as-is rule recorded, no-extrapolation rule recorded, stale 503 contingency removed, facts-trace line points at the 7/14 re-verification.

**app/blog/everything-that-broke/page.tsx** (content only — stays parked)
- Scoreboard paragraph date-stamped to the audit ($0 across the four months) with the current $99 total noted in one sentence, no extrapolation.
- "Every purchase lands in the public revenue number" now says "— one so far."

## Deliberately NOT in this PR
- No change to `lib/blog.ts` — the post keeps its far-future `publishAt`; the calendar is frozen until the email ships (#122), and the publish flip is its own one-line PR on Nalin's go.
- No send code, cron, or template changes.

Numbers verified against the PR #125 COURSE_FACTS refresh (352 / 297 / $99, Stripe + prod DB, 2026-07-14); that refresh is still unmerged with #125, so main's COURSE_FACTS lags it — reviewer should cross-check there, not main.

`pnpm build` passes; vitest shows only the 4 pre-existing baseline failures (email module + waitlist duplicate, identical on main).

Part of #122. Revenue presentation per #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)