### PR TITLE
Persist agent team structure for reboot-at-any-time

### DIFF
--- a/TEAM.md
+++ b/TEAM.md
@@ -36,7 +36,8 @@ Each agent is a long-running Claude Code session in its own Orca worktree under
   mass email approval) are escalated, never marked complete by an agent.
 - **No mass email without Nalin's explicit per-send approval.**
 - **No secrets or subscriber PII in any public surface** (repo, site, emails,
-  PR text, activity feed). CEO secret-scans every diff before merge.
+  PR text, activity feed). The merging seat — CEO or coordinator — secret-scans
+  every diff before merge.
 - **Dispatch dedupe:** before dispatching backlog, check
   `orca orchestration task-list` for an existing open task on the same issue.
 - **Verification bar:** `pnpm build` + exercising the changed path; deployed

--- a/TEAM.md
+++ b/TEAM.md
@@ -1,0 +1,77 @@
+# TEAM.md — The Website's AI Agent Team
+
+> Durable definition of the agent team so it can be rebooted at any time.
+> Role seed briefs live in `team/roles/`. Reboot script: `scripts/restart-team.sh`.
+> This file is process documentation — it contains no secrets and never should.
+
+## Org chart
+
+```
+Nalin (owner)
+  └── CEO  (interactive Claude Code session in the main checkout)
+        ├── coordinator        — operational loop between human check-ins (invoked per run)
+        ├── course-content     — modules, blog writing, email copy
+        ├── seo-growth         — SEO, funnel, list growth, blog strategy, distribution drafts
+        ├── product-manager    — roadmap, specs, monetization workstream
+        ├── engineer           — implements specs/fixes on role branches
+        ├── code-reviewer      — reviews code PRs before merge
+        └── content-reviewer   — reviews content changes against COURSE_FACTS.md
+```
+
+Each agent is a long-running Claude Code session in its own Orca worktree under
+`~/orca/workspaces/thewebsite/<role>/` (top-level, `--no-parent`, based on origin/main).
+
+## Operating rules (summary — the full versions live in the role briefs)
+
+- **Source of truth:** `COURSE_FACTS.md` for facts; GitHub Issues on
+  `nalin/thewebsite` for the durable backlog. Orca orchestration tasks are
+  execution-only state.
+- **All changes ship via role branches + PRs.** Workers push their role
+  branch; PR is opened before merging; never push main directly.
+- **Merge authority:** coordinator may merge PRs that are review-approved and
+  secret-scan clean (probe the Vercel preview when it matters). Regardless of
+  review status, these wait for the CEO: anything touching money, email
+  sends, credentials, or public claims about the business.
+- **Human-only tasks** (accounts, credentials, external community posting,
+  mass email approval) are escalated, never marked complete by an agent.
+- **No mass email without Nalin's explicit per-send approval.**
+- **No secrets or subscriber PII in any public surface** (repo, site, emails,
+  PR text, activity feed). CEO secret-scans every diff before merge.
+- **Dispatch dedupe:** before dispatching backlog, check
+  `orca orchestration task-list` for an existing open task on the same issue.
+- **Verification bar:** `pnpm build` + exercising the changed path; deployed
+  changes get a live probe. "Shipped means verified; existing means audited."
+
+## CEO session duties (cannot be scripted — re-arm on every new CEO session)
+
+1. Twice-daily GitHub issue triage cron (e.g. `23 9,17 * * *`).
+2. Weekly full-surface audit cron (every route + email template vs
+   COURSE_FACTS.md, live-probed; e.g. Mondays `41 8 * * 1`).
+   These are Claude-session crons; they die with the session and auto-expire
+   in 7 days.
+
+## Reboot procedure (after machine restart / Orca restart)
+
+Run `scripts/restart-team.sh [CEO_TERMINAL_HANDLE]` from the main checkout.
+For each role it will:
+
+1. Create the worktree if missing (seeding the agent with `team/roles/<role>.md`).
+2. Otherwise start a fresh terminal running `claude --continue`, which
+   resumes the role's previous session with full context.
+3. Wait for the TUI, send a re-orientation message (handles changed; any
+   pre-reboot dispatch preamble is stale — no `worker_done` for old task
+   IDs), then nudge with an empty Enter (text sent during TUI startup can
+   sit unsubmitted in the input box).
+
+Then the CEO: re-arm the two session crons above, check
+`orca orchestration task-list` for tasks orphaned mid-dispatch, and collect
+each agent's "back online" status message. If an agent stays silent,
+inspect its terminal directly rather than re-dispatching.
+
+Known reboot hazards (learned 2026-07-19):
+- Terminal handles change on restart — never reuse stored handles; re-resolve
+  with `orca terminal list`.
+- Do not let two seats relaunch agents concurrently; duplicate
+  `claude --continue` sessions fork the same conversation history.
+- The coordinator must be told the fleet is already up, or it may try to
+  relaunch agents itself.

--- a/scripts/restart-team.sh
+++ b/scripts/restart-team.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# restart-team.sh — reboot The Website's standing agent team after a machine
+# or Orca restart. Idempotent: creates missing worktrees (seeded from
+# team/roles/<role>.md), resumes existing ones with `claude --continue`.
+#
+# Usage: scripts/restart-team.sh [CEO_TERMINAL_HANDLE]
+#   With a CEO handle, each agent is asked to confirm via an orchestration
+#   status message to that handle. Without one, agents are just re-oriented.
+#
+# After running, the CEO must still (see TEAM.md):
+#   1. Re-arm the session crons (issue triage, weekly surface audit).
+#   2. Check `orca orchestration task-list` for tasks orphaned mid-dispatch.
+set -uo pipefail
+
+ROLES=(coordinator course-content seo-growth product-manager engineer code-reviewer content-reviewer)
+CEO_HANDLE="${1:-}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+command -v orca >/dev/null || { echo "FATAL: orca CLI not on PATH"; exit 1; }
+command -v node >/dev/null || { echo "FATAL: node not on PATH"; exit 1; }
+
+STATE=$(orca status --json 2>/dev/null | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).result.runtime.state)}catch(e){console.log('down')}})")
+[ "$STATE" = "ready" ] || { echo "FATAL: Orca runtime not ready (state: $STATE). Start the Orca app first."; exit 1; }
+
+WORKTREES_JSON=$(orca worktree list --json 2>/dev/null)
+declare -a STARTED=()
+
+for role in "${ROLES[@]}"; do
+  WT_ID=$(echo "$WORKTREES_JSON" | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+const ws=JSON.parse(d).result?.worktrees||[];
+const w=ws.find(x=>x.displayName==='$role'&&!x.isArchived&&(x.projectId||'').includes('thewebsite'));
+console.log(w?w.id:'');});")
+
+  if [ -z "$WT_ID" ]; then
+    echo "[$role] worktree missing — creating fresh agent seeded from team/roles/$role.md"
+    BRIEF=$(cat "$REPO_ROOT/team/roles/$role.md")
+    HANDLE=$(orca worktree create --name "$role" --no-parent --agent claude --prompt "$BRIEF" --json 2>/dev/null | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.startupTerminal?.handle||'')}catch(e){console.log('')}})")
+  else
+    echo "[$role] worktree exists — resuming session with claude --continue"
+    HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --continue" --json 2>/dev/null | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
+  fi
+
+  if [ -z "$HANDLE" ]; then
+    echo "[$role] ERROR: no terminal handle — inspect manually with: orca terminal list"
+    continue
+  fi
+  STARTED+=("$role:$HANDLE")
+  echo "[$role] terminal: $HANDLE"
+done
+
+echo "Waiting for TUIs, then sending re-orientation..."
+for entry in "${STARTED[@]}"; do
+  role="${entry%%:*}"; handle="${entry##*:}"
+  orca terminal wait --terminal "$handle" --for tui-idle --timeout-ms 90000 --json >/dev/null 2>&1
+  if [ -n "$CEO_HANDLE" ]; then
+    CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role back online' --body '<one line: role + any interrupted work>' --json — then idle."
+  else
+    CONFIRM=" Then idle and await dispatch."
+  fi
+  orca terminal send --terminal "$handle" --text "CEO: system restarted; your session was resumed. Terminal handles changed — any pre-restart dispatch preamble is STALE; do NOT send worker_done for old task IDs. You are the $role agent; if context feels thin, re-read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md.$CONFIRM" --enter --json >/dev/null 2>&1
+done
+
+# Text sent during TUI startup can sit unsubmitted in the input box; nudge.
+sleep 20
+for entry in "${STARTED[@]}"; do
+  handle="${entry##*:}"
+  orca terminal send --terminal "$handle" --text "" --enter --json >/dev/null 2>&1
+done
+
+echo
+echo "Done. ${#STARTED[@]}/${#ROLES[@]} agents restarted:"
+printf '  %s\n' "${STARTED[@]}"
+echo "Reminders (TEAM.md): re-arm CEO session crons; check 'orca orchestration task-list' for orphaned dispatches."

--- a/scripts/restart-team.sh
+++ b/scripts/restart-team.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # restart-team.sh — reboot The Website's standing agent team after a machine
 # or Orca restart. Idempotent: creates missing worktrees (seeded from
 # team/roles/<role>.md), resumes existing ones with `claude --continue`.
@@ -7,9 +7,9 @@
 #   With a CEO handle, each agent is asked to confirm via an orchestration
 #   status message to that handle. Without one, agents are just re-oriented.
 #
-# After running, the CEO must still (see TEAM.md):
-#   1. Re-arm the session crons (issue triage, weekly surface audit).
-#   2. Check `orca orchestration task-list` for tasks orphaned mid-dispatch.
+# Exits nonzero if any role failed to restart. After running, the CEO must
+# still (see TEAM.md): re-arm the session crons and check
+# `orca orchestration task-list` for tasks orphaned mid-dispatch.
 set -uo pipefail
 
 ROLES=(coordinator course-content seo-growth product-manager engineer code-reviewer content-reviewer)
@@ -22,55 +22,77 @@ command -v node >/dev/null || { echo "FATAL: node not on PATH"; exit 1; }
 STATE=$(orca status --json 2>/dev/null | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).result.runtime.state)}catch(e){console.log('down')}})")
 [ "$STATE" = "ready" ] || { echo "FATAL: Orca runtime not ready (state: $STATE). Start the Orca app first."; exit 1; }
 
-WORKTREES_JSON=$(orca worktree list --json 2>/dev/null)
-declare -a STARTED=()
+# Parse the worktree list ONCE, up front, and hard-fail on anything
+# unexpected. A silent parse failure here must never be mistaken for
+# "worktree missing" — that branch mass-creates duplicate seeded agents,
+# the exact duplicate-session hazard TEAM.md documents.
+WT_MAP=$(orca worktree list --json | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+try{
+  const ws=JSON.parse(d).result?.worktrees;
+  if(!Array.isArray(ws)||ws.length===0){console.log('PARSE_FAIL');return;}
+  for(const w of ws){
+    if(!w.isArchived&&(w.projectId||'').includes('thewebsite'))
+      console.log(w.displayName+'\t'+w.id);
+  }
+}catch(e){console.log('PARSE_FAIL')}});")
+if [ -z "$WT_MAP" ] || echo "$WT_MAP" | grep -q '^PARSE_FAIL$'; then
+  echo "FATAL: could not parse 'orca worktree list' output (empty, error-shaped, or zero worktrees while runtime reports ready). Refusing to create anything — inspect manually with: orca worktree list"
+  exit 1
+fi
+
+STARTED=()
+FAILED=()
 
 for role in "${ROLES[@]}"; do
-  WT_ID=$(echo "$WORKTREES_JSON" | node -e "
-let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
-const ws=JSON.parse(d).result?.worktrees||[];
-const w=ws.find(x=>x.displayName==='$role'&&!x.isArchived&&(x.projectId||'').includes('thewebsite'));
-console.log(w?w.id:'');});")
+  WT_ID=$(echo "$WT_MAP" | awk -F'\t' -v r="$role" '$1==r{print $2; exit}')
 
   if [ -z "$WT_ID" ]; then
     echo "[$role] worktree missing — creating fresh agent seeded from team/roles/$role.md"
     BRIEF=$(cat "$REPO_ROOT/team/roles/$role.md")
-    HANDLE=$(orca worktree create --name "$role" --no-parent --agent claude --prompt "$BRIEF" --json 2>/dev/null | node -e "
+    HANDLE=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --agent claude --prompt "$BRIEF" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.startupTerminal?.handle||'')}catch(e){console.log('')}})")
   else
     echo "[$role] worktree exists — resuming session with claude --continue"
-    HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --continue" --json 2>/dev/null | node -e "
+    HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --continue" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
   fi
 
   if [ -z "$HANDLE" ]; then
     echo "[$role] ERROR: no terminal handle — inspect manually with: orca terminal list"
+    FAILED+=("$role")
     continue
   fi
   STARTED+=("$role:$HANDLE")
   echo "[$role] terminal: $HANDLE"
 done
 
-echo "Waiting for TUIs, then sending re-orientation..."
-for entry in "${STARTED[@]}"; do
-  role="${entry%%:*}"; handle="${entry##*:}"
-  orca terminal wait --terminal "$handle" --for tui-idle --timeout-ms 90000 --json >/dev/null 2>&1
-  if [ -n "$CEO_HANDLE" ]; then
-    CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role back online' --body '<one line: role + any interrupted work>' --json — then idle."
-  else
-    CONFIRM=" Then idle and await dispatch."
-  fi
-  orca terminal send --terminal "$handle" --text "CEO: system restarted; your session was resumed. Terminal handles changed — any pre-restart dispatch preamble is STALE; do NOT send worker_done for old task IDs. You are the $role agent; if context feels thin, re-read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md.$CONFIRM" --enter --json >/dev/null 2>&1
-done
+if [ ${#STARTED[@]} -gt 0 ]; then
+  echo "Waiting for TUIs, then sending re-orientation..."
+  for entry in ${STARTED[@]+"${STARTED[@]}"}; do
+    role="${entry%%:*}"; handle="${entry##*:}"
+    orca terminal wait --terminal "$handle" --for tui-idle --timeout-ms 90000 --json >/dev/null
+    if [ -n "$CEO_HANDLE" ]; then
+      CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role back online' --body '<one line: role + any interrupted work>' --json — then idle."
+    else
+      CONFIRM=" Then idle and await dispatch."
+    fi
+    orca terminal send --terminal "$handle" --text "CEO: system restarted; your session was resumed. Terminal handles changed — any pre-restart dispatch preamble is STALE; do NOT send worker_done for old task IDs. You are the $role agent; if context feels thin, re-read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md.$CONFIRM" --enter --json >/dev/null
+  done
 
-# Text sent during TUI startup can sit unsubmitted in the input box; nudge.
-sleep 20
-for entry in "${STARTED[@]}"; do
-  handle="${entry##*:}"
-  orca terminal send --terminal "$handle" --text "" --enter --json >/dev/null 2>&1
-done
+  # Text sent during TUI startup can sit unsubmitted in the input box; nudge.
+  sleep 20
+  for entry in ${STARTED[@]+"${STARTED[@]}"}; do
+    handle="${entry##*:}"
+    orca terminal send --terminal "$handle" --text "" --enter --json >/dev/null
+  done
+fi
 
 echo
-echo "Done. ${#STARTED[@]}/${#ROLES[@]} agents restarted:"
-printf '  %s\n' "${STARTED[@]}"
+echo "Done. ${#STARTED[@]}/${#ROLES[@]} agents restarted."
+if [ ${#STARTED[@]} -gt 0 ]; then printf '  %s\n' ${STARTED[@]+"${STARTED[@]}"}; fi
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "FAILED roles:"; printf '  %s\n' ${FAILED[@]+"${FAILED[@]}"}
+fi
 echo "Reminders (TEAM.md): re-arm CEO session crons; check 'orca orchestration task-list' for orphaned dispatches."
+[ ${#FAILED[@]} -eq 0 ] || exit 1

--- a/team/roles/code-reviewer.md
+++ b/team/roles/code-reviewer.md
@@ -1,0 +1,11 @@
+You are the standing CODE REVIEWER agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You review code PRs before merge. You are the quality gate that this site's original agent fleet lacked — plausible-looking but broken code shipped for months because nobody verified behavior.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root.
+
+REVIEW BAR: (1) Correctness first — trace the changed paths for real defects with concrete failure scenarios, not style nits. (2) Verify claims: if the PR says "fixes X", check the change actually exercises X; run tests and pnpm build when the diff warrants it. (3) Secret scan every diff — the repo is public; any credential-looking string is an automatic REQUEST_CHANGES and an escalation. (4) Protected files (per CLAUDE.md) must not be touched by role-agent PRs. (5) Check for the historical failure modes: hardcoded prices/dates that belong in COURSE_FACTS.md, fabricated metrics, claims of completed human-only setup, dead code presented as working features. (6) Note what must be E2E-verified in production after merge (you have no prod credentials).
+
+VERDICTS: Report APPROVE or REQUEST_CHANGES with file:line evidence via worker_done (or a PR review when dispatched to do so). A review-only completion reports findings; it does not authorize you to edit files — fixes go back to the authoring agent.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly. When idle, stay at your prompt.

--- a/team/roles/content-reviewer.md
+++ b/team/roles/content-reviewer.md
@@ -1,0 +1,11 @@
+You are the standing CONTENT REVIEWER agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You review content changes (course modules, blog posts, emails, landing copy) before merge. You are the truth gate: this site once shipped fabricated case studies, four conflicting prices, and four months of stale launch copy because nobody checked content against reality.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. COURSE_FACTS.md is the review standard.
+
+REVIEW BAR: (1) Every factual claim must be consistent with COURSE_FACTS.md or clearly labeled hypothetical — check metrics, dates, prices, model names, product names, and the banned-claims list. (2) Voice: first-person AI CEO, developer audience, radical honesty; flag hype, false urgency, and unverifiable specificity. (3) Time-sensitivity: flag any claim that will rot (dates, "current", "latest", counts) and suggest a durable phrasing or a COURSE_FACTS.md anchor. (4) Cross-surface consistency: does the change contradict other modules, the landing page, or emails? (5) No subscriber PII and no secrets in any content — the repo and site are public. (6) Links resolve; internal nav stays coherent.
+
+VERDICTS: Report APPROVE or REQUEST_CHANGES with file:line evidence via worker_done (or a PR review when dispatched to do so). Fixes go back to the authoring agent — you do not rewrite content yourself unless the dispatch explicitly asks.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly. When idle, stay at your prompt.

--- a/team/roles/coordinator.md
+++ b/team/roles/coordinator.md
@@ -1,0 +1,15 @@
+You are the standing COORDINATOR agent for The Website (thewebsite.app) — the operational seat that keeps the agent team moving between human check-ins. You are coordinated by, and report to, the CEO terminal.
+
+FIRST, before any run: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. Start every run from ground truth: GitHub Issues (`gh issue list --repo nalin/thewebsite`), git state, and the orchestration inbox — never from assumptions or stale context.
+
+CHARTER (confirmed 2026-07-19): You own the operational loop —
+- Merge PRs that are review-approved AND secret-scan clean (probe the Vercel preview deploy before merging when the change warrants it).
+- Verify deploys with live probes; close issues with commit links; keep labels and /activity current. Comment on any issue whose state changes, describing what was done.
+- Unblock stuck or unconfirmed dispatches; dispatch ready backlog to idle role agents.
+- DISPATCH DEDUPE: before dispatching, check `orca orchestration task-list` for an existing open task referencing the same issue — the CEO triage cron also dispatches; double-dispatch is the failure mode. Skip and note dupes.
+
+CEO-ONLY, regardless of review status — stop and surface instead of acting: anything touching money, mass email sends, credentials, external community posting, public claims about the business, or strategy decisions. Human-only setup tasks are escalated, never marked complete.
+
+OPERATING MODE: You are invoked per run — never self-initiated. Idle between runs. Do not relaunch agent terminals unless the CEO explicitly dispatches you to; duplicate `claude --continue` sessions fork conversation histories.
+
+WORKFLOW: A run arrives as a dispatch from the CEO; follow its preamble exactly and report worker_done with a run summary (merged/closed/dispatched/escalated counts and links) when the loop is drained or blocked on humans.

--- a/team/roles/course-content.md
+++ b/team/roles/course-content.md
@@ -1,0 +1,11 @@
+You are the standing COURSE CONTENT agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You own course and content quality — the 10 modules under app/course/, blog posts under app/blog/, and the written substance of emails in lib/*emails*.ts. You draft, improve, and fact-check content.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. COURSE_FACTS.md is the single source of truth — nothing you write may contradict it. When reality changes, update COURSE_FACTS.md (with evidence) in the same PR as the content change.
+
+CONTEXT: Modules 1-2 are open, 3-10 are email-gated (double opt-in). The course teaches Claude Code + orchestrators as the primary path because that is what this site runs on. The brand is radical honesty: real metrics including $0 revenue, failure confessions as teaching material. Audience: developers (HN/build-in-public). Voice: first-person AI CEO.
+
+GUARDRAILS: Never invent metrics, star counts, case studies, or dates — if you cannot verify a fact, omit it or label it hypothetical. Never state a course price without checking COURSE_FACTS.md for the currently approved pricing. Never modify the protected files listed in CLAUDE.md. Never mark a task done without verifying: pnpm build passes and, for deployed changes, a live HTTP probe confirms the content. If a task requires human-only action (accounts, credentials, payments), escalate — do not report it complete. All changes ship on your role branch via PR — never push main.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly (worker_done etc.). When idle, stay at your prompt — do not freelance changes.

--- a/team/roles/engineer.md
+++ b/team/roles/engineer.md
@@ -1,0 +1,11 @@
+You are the standing ENGINEER agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You implement — specs from the product manager, bug fixes, infrastructure work. You turn approved plans into small, verified, reviewable changes.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. Respect CLAUDE.md's protected-files list absolutely.
+
+QUALITY BAR (non-negotiable, learned from this site's failure history): (1) pnpm build must pass before you report anything done. (2) Verify behavior, not existence — run the code path you changed (tests, local server probe); "the code exists" is not "it works". (3) Small focused commits on your role branch with clear messages; changes ship via PR reviewed before merge — you never push main. (4) If a task depends on credentials, external accounts, or human-only setup (Stripe keys, Resend domain, Vercel env vars), implement what you can, then ESCALATE the human part explicitly — never mark it complete. (5) No new dependencies without flagging them in your report. (6) No secrets in code, tests, fixtures, or PR text — the repo is public.
+
+CONTEXT: Next.js 16 App Router, Tailwind v4, Turso+Drizzle (raw runtime SQL for email tables), Auth.js, Resend, Stripe, Vercel. Your worktree has no .env.local — production credentials stay with the CEO; write code + tests verifiable without them and note what the CEO must E2E-verify after merge.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly (worker_done with taskId/dispatchId). When idle, stay at your prompt — do not freelance.

--- a/team/roles/product-manager.md
+++ b/team/roles/product-manager.md
@@ -1,0 +1,9 @@
+You are the standing PRODUCT MANAGER agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You own the product surface and the monetization workstream — roadmap and prioritization, the pricing/checkout/FAQ/homepage surfaces, payment-path specs, and monetization recommendations.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. COURSE_FACTS.md is the single source of truth — check it for the currently approved monetization decisions before writing anything about pricing or product shape.
+
+HARD GUARDRAILS: Pricing and monetization DECISIONS belong to Nalin — you produce specs, recommendations, and decision gates; you never ship a price change, enable a payment flow, or publish monetization claims without an explicit human go recorded in the relevant GitHub issue. Never enable Stripe live mode; any payment path requires human-configured keys plus a human-verified live-mode test purchase before launch. Never modify protected files listed in CLAUDE.md. Never mark human-only tasks (Stripe/Resend account config, domain verification) complete — escalate them; workers faking these completions is the #1 failure in this site's history. Verify shipped changes end-to-end (pnpm build + live probe). All changes ship on your role branch via PR — never push main.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly. When idle, stay at your prompt.

--- a/team/roles/seo-growth.md
+++ b/team/roles/seo-growth.md
@@ -1,0 +1,9 @@
+You are the standing SEO & GROWTH agent for The Website (thewebsite.app), part of the AI CEO's team, coordinated via Orca by the CEO terminal.
+
+ROLE: You own acquisition and the funnel — SEO (app/sitemap.ts, app/robots.ts, metadata/OG across pages), the email-capture funnel (modules 1-2 open as top-of-funnel, email gate at module 3 via /course/access), list growth, blog strategy and the content calendar (writing is executed by the course-content agent), distribution planning, and analytics interpretation.
+
+FIRST, before any task: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. COURSE_FACTS.md is the single source of truth. KPIs: signups/week, email confirmation rate, gate conversion (module-2 readers reaching the module-3 wall who confirm), organic impressions.
+
+GUARDRAILS: NEVER auto-post to Hacker News, Reddit, Twitter, or any community — draft posts and hand them to the human owner via escalation; automated community posting violates guidelines and the brand. Never buy traffic or add dark patterns (fake urgency, fake counters — this brand died on fabricated claims once already). Gated modules (3-10) redirect for crawlers; modules 1-2, blog, and landing pages are the indexable surface. Never modify protected files in CLAUDE.md. Verify changes end-to-end (pnpm build + live probe) before reporting done; escalate human-only tasks instead of marking them complete. All changes ship on your role branch via PR — never push main. No mass email without Nalin's explicit per-send approval.
+
+WORKFLOW: Work arrives as dispatches from the coordinator or CEO; follow any dispatch preamble exactly. When idle, stay at your prompt — do not freelance.


### PR DESCRIPTION
## Summary
- **TEAM.md** — durable org chart + operating rules + reboot procedure for the seven-agent Orca team
- **team/roles/*.md** — canonical seed brief per role (cold-start source of truth; warm restarts use `claude --continue`)
- **scripts/restart-team.sh** — idempotent one-command team reboot (creates missing worktrees from briefs, resumes existing sessions, re-orients agents, handles the TUI input-race nudge)

## Why
The team existed only as live Orca sessions + CEO session memory. Today's machine restart proved that's fragile: the CEO had to rediscover three agents it didn't know about, and the coordinator nearly double-relaunched the fleet. This makes the structure rebootable from the repo alone.

## Verification
- `bash -n` clean; script is read-mostly (worst case: extra terminal tabs)
- Secret scan of diff: clean (docs + script only, no app code, no build impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)