### PR TITLE
restart-team.sh: pass explicit base branch to worktree create

### DIFF
--- a/scripts/restart-team.sh
+++ b/scripts/restart-team.sh
@@ -16,6 +16,14 @@ ROLES=(coordinator course-content seo-growth product-manager engineer code-revie
 CEO_HANDLE="${1:-}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Base ref for freshly created role worktrees. TEAM.md documents them as
+# "based on origin/main", so assert that rather than inheriting Orca's implicit
+# default. Note the default is NOT a stored repo setting: `orca repo show --repo
+# name:thewebsite --json` exposes no base-branch field (verified 2026-07-17);
+# Orca infers it from git's origin/HEAD, which resolves to refs/remotes/origin/main
+# here but is ambient state nothing pins. Passing it makes the claim enforced.
+BASE_BRANCH="${BASE_BRANCH:-origin/main}"
+
 command -v orca >/dev/null || { echo "FATAL: orca CLI not on PATH"; exit 1; }
 command -v node >/dev/null || { echo "FATAL: node not on PATH"; exit 1; }
 
@@ -48,9 +56,17 @@ for role in "${ROLES[@]}"; do
   WT_ID=$(echo "$WT_MAP" | awk -F'\t' -v r="$role" '$1==r{print $2; exit}')
 
   if [ -z "$WT_ID" ]; then
-    echo "[$role] worktree missing — creating fresh agent seeded from team/roles/$role.md"
+    echo "[$role] worktree missing — creating fresh agent seeded from team/roles/$role.md (base: $BASE_BRANCH)"
+    # Fail closed on a base ref that doesn't resolve: creating role worktrees
+    # from the wrong (or a silently-defaulted) base is the failure #134 is about.
+    # Checked lazily so a resume-only restart is never blocked by it.
+    if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null; then
+      echo "[$role] ERROR: base ref '$BASE_BRANCH' does not resolve in $REPO_ROOT — run 'git -C $REPO_ROOT fetch origin' and retry."
+      FAILED+=("$role")
+      continue
+    fi
     BRIEF=$(cat "$REPO_ROOT/team/roles/$role.md")
-    HANDLE=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --agent claude --prompt "$BRIEF" --json | node -e "
+    HANDLE=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --base-branch "$BASE_BRANCH" --agent claude --prompt "$BRIEF" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.startupTerminal?.handle||'')}catch(e){console.log('')}})")
   else
     echo "[$role] worktree exists — resuming session with claude --continue"


### PR DESCRIPTION
Residual from the PR #132 code review. `scripts/restart-team.sh` called `orca worktree create` without `--base-branch`, so TEAM.md's "based on origin/main" claim silently relied on Orca's repo default.

fixes #134

## What I found

`--base-branch <ref>` **is** supported by this CLI version, so the explicit flag is used (the issue's fallback path wasn't needed).

The more interesting finding: **there is no stored repo default to read.** The task suggested deriving it from `orca repo show --repo <selector> --json`, but that record exposes **no base-branch field at all** (verified 2026-07-17 — the repo object's keys are `id, path, displayName, badgeColor, addedAt, kind, externalWorktreeVisibility, externalWorktreeVisibilityLegacy, gitUsername, upstream, gitRemoteIdentity, projectHostSetupMethod, hookSettings, repoIcon`). Orca infers the base from git's `origin/HEAD`, which resolves to `refs/remotes/origin/main` here — correct today, but ambient state nothing pins. That makes the explicit flag the right call rather than a stylistic one.

Also noted: `path:` selectors resolve only against the **canonical registered repo path** (`/Users/nalin/code/thewebsite`), not a worktree path. That's consistent with TEAM.md line 56 ("run from the main checkout"), and the script already fails closed if it doesn't resolve, so it's left alone.

## Changes (script only, 18 insertions)

- `BASE_BRANCH="${BASE_BRANCH:-origin/main}"` — env-overridable, documented inline with the verification command and the 2026-07-17 date.
- Pass `--base-branch "$BASE_BRANCH"` to `orca worktree create`.
- Fail closed when the base ref doesn't resolve, rather than letting Orca pick something. Checked **lazily** (inside the create branch) so a resume-only restart is never blocked by a stale/missing ref.
- Echo the base in the create log line.

The bash-3.2 guards and fail-closed worktree-list parsing from #132 are untouched.

## Verification

- `bash -n` clean under both the default bash and **`/bin/bash` 3.2.57** (the macOS system bash the #132 guards target).
- **shellcheck v0.11.0: clean, exit 0.** It wasn't installed, so I pulled it ephemerally via `pnpm dlx shellcheck@latest` — and sanity-checked that it really analyzes (it flags SC2034/SC2154/SC2086 on a deliberately-bad script), so "clean" isn't a no-op pass.
- Guard tested behaviorally, not just parsed: `origin/main` → passes (resolves 0433f02); `origin/nope` → trips, exit 1; `BASE_BRANCH=origin/HEAD` override → passes.
- `pnpm build` passes — no app impact (`scripts/` isn't in the tsconfig/next build).
- **Did not run a team restart**, per the task. The one thing not exercised end-to-end is a real `orca worktree create --base-branch` call; doing so would spawn a duplicate seeded agent, the exact hazard TEAM.md warns about. Flag support is evidenced by the CLI's own `--help` output.

## Reviewer note

The lazy base-ref guard is slightly beyond a literal one-flag fix. I included it because it directly serves the "based on origin/main" guarantee — but it's cleanly separable if you'd rather keep the diff to the flag alone.

Do not merge — code-reviewer gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
