### PR TITLE
Reconcile TEAM.md and OPERATIONS.md: one team model, one merge-authority definition (fixes #133)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -40,9 +40,26 @@ Four principles, in priority order:
 The CEO seat is the only one the human touches — **Nalin interacts with the
 CEO, and the CEO coordinates everyone else.**
 
+**The CEO is a function, not a single session.** It runs as two instantiations
+with one mandate:
+
+- **Interactive CEO terminal** — owner-facing. Where Nalin checks in, where
+  decisions get made, and where human-only items are escalated.
+- **Scheduled `ceo-coordinator` runs** — the operational loop between check-ins.
+  An Orca automation (`13 */2 * * *`, host-local — every two hours) starts a
+  CEO-persona session in the shared `coordinator` worktree; it merges, unblocks
+  stuck dispatches, dispatches ready backlog, and closes issues, then idles
+  until the next run.
+
+Both instantiations hold the **same merge bar** (§4) and the **same reserved
+escalations**: money, mass email sends, credentials, external community
+posting, and public claims about the business. Neither instantiation decides
+those — both surface them to Nalin. Whichever one is merging is "the CEO" for
+the purposes of this manual.
+
 | Role | Owns |
 |---|---|
-| **CEO** | Coordinates and scopes work, dispatches tasks, reviews and merges PRs, runs the live verification probe, escalates human-only items to Nalin. The single point of contact for the owner. |
+| **CEO** | Coordinates and scopes work, dispatches tasks, reviews and merges PRs, runs the live verification probe, escalates human-only items to Nalin. The single point of contact for the owner. Runs both as an interactive terminal and as scheduled `ceo-coordinator` sessions (above). |
 | **course-content** | The 10 course modules, the 7 blog posts, and email copy. |
 | **seo-growth** | SEO, funnel and list health, distribution/launch drafts, blog strategy. Drafts outreach; never auto-posts to communities. |
 | **product-manager** | Roadmap, pricing and monetization strategy, product specs. Produces recommendations and specs; never ships a price or payment flow without Nalin's go. |
@@ -53,6 +70,12 @@ CEO, and the CEO coordinates everyone else.**
 Each non-CEO role is a persistent Orca agent in its own git worktree. Reviewers
 are separate seats precisely so no one reviews their own work.
 
+The live roster, the per-role seed briefs (`team/roles/`), and the procedure for
+rebooting the fleet live in [`TEAM.md`](./TEAM.md) — the roster/reboot annex to
+this manual. This doc is binding and defines *how work ships*; TEAM.md records
+*who currently fills the seats* and how to bring them back up. Where the two
+disagree, this doc wins.
+
 ---
 
 ## 3. How work flows
@@ -62,13 +85,18 @@ any non-trivial change:
 
 1. **Idea or bug → GitHub issue.** The issue is the durable backlog entry and
    the place the outcome is recorded.
-2. **CEO scopes it and dispatches an Orca task** to the owning agent.
+2. **CEO scopes it and dispatches an Orca task** to the owning agent. Check
+   `orca orchestration task-list` for an open task on the same issue first —
+   both the triage cron and the scheduled coordinator runs dispatch, so
+   **double-dispatch is the standing failure mode.** Skip and note duplicates.
 3. **Agent works on its own branch** (off its role branch), committing as it goes.
 4. **Agent pushes and opens/receives a PR**, reporting the branch name and head
    commit back to the CEO.
 5. **Review gate** (see §4) — the right reviewer approves or requests changes.
-6. **CEO merges** after approval *and* a live verification probe of the preview
-   or production deploy.
+6. **CEO merges** after approval, a **secret-scan of the diff** (§6), *and* a
+   live verification probe of the preview or production deploy. The merging
+   seat is whichever CEO instantiation is running (§2); the bar is identical
+   either way.
 7. **CEO comments the outcome on the issue** with commit/PR links and closes it.
 
 By policy, **every** change lands via a branch and a PR the CEO merges — no
@@ -96,6 +124,12 @@ become follow-up GitHub issues rather than holding the PR. Reviewers never
 review their own work. Regardless of lane, the **CEO always does the final
 merge and the live probe** — the review gate never replaces verification.
 
+The merge bar is the same for both CEO instantiations (§2): **review-approved,
+secret-scan clean, and live-probe verified.** A scheduled `ceo-coordinator` run
+merges on exactly these terms and no looser ones; if a PR touches money, mass
+email, credentials, external posting, or public business claims, it waits for
+Nalin regardless of how green the reviews are.
+
 ---
 
 ## 5. Definition of done
@@ -119,8 +153,10 @@ that reports one of them complete is wrong by definition.
 - **No secrets or PII, ever, in anything public.** The repo is public. Secrets
   live only in environment variables / Vercel env / gitignored `.env.local`.
   Subscriber email addresses never appear in content, public logs, activity
-  events, or reports. The CEO secret-scans every PR; a hit blocks the merge.
-  Need a credential for a task? Escalate — never paste one anywhere.
+  events, or reports. **The merging seat secret-scans every diff before merge**
+  — interactive CEO or scheduled `ceo-coordinator` run, no difference — and a
+  hit blocks the merge. Need a credential for a task? Escalate — never paste
+  one anywhere.
 - **No mass email without Nalin's explicit per-send approval.** The nurture
   cron stays **off** until he approves it; each send is its own approval.
 - **No fabricated facts, metrics, URLs, or testimonials.** Every public claim

--- a/TEAM.md
+++ b/TEAM.md
@@ -1,6 +1,10 @@
 # TEAM.md — The Website's AI Agent Team
 
 > Durable definition of the agent team so it can be rebooted at any time.
+> [`OPERATIONS.md`](./OPERATIONS.md) is the **binding operating manual** — how
+> work ships, the review lanes, the merge bar, and the standing rules. This file
+> is its **roster/reboot annex**: who fills the seats and how to bring them back
+> up. Where the two disagree, OPERATIONS.md wins.
 > Role seed briefs live in `team/roles/`. Reboot script: `scripts/restart-team.sh`.
 > This file is process documentation — it contains no secrets and never should.
 
@@ -8,8 +12,10 @@
 
 ```
 Nalin (owner)
-  └── CEO  (interactive Claude Code session in the main checkout)
-        ├── coordinator        — operational loop between human check-ins (invoked per run)
+  └── CEO function — two instantiations, one mandate (OPERATIONS.md §2)
+        │   • interactive CEO terminal    — owner-facing; decisions, escalations
+        │   • scheduled ceo-coordinator   — operational loop; every 2h (13 */2 * * *)
+        │
         ├── course-content     — modules, blog writing, email copy
         ├── seo-growth         — SEO, funnel, list growth, blog strategy, distribution drafts
         ├── product-manager    — roadmap, specs, monetization workstream
@@ -18,7 +24,12 @@ Nalin (owner)
         └── content-reviewer   — reviews content changes against COURSE_FACTS.md
 ```
 
-Each agent is a long-running Claude Code session in its own Orca worktree under
+The coordinator is **not a subordinate role** — it is the CEO function running on
+a schedule. The interactive CEO works in the main checkout (`~/code/thewebsite`);
+scheduled `ceo-coordinator` runs reuse the shared `coordinator` worktree and
+never create their own.
+
+Each other agent is a long-running Claude Code session in its own Orca worktree under
 `~/orca/workspaces/thewebsite/<role>/` (top-level, `--no-parent`, based on origin/main).
 
 ## Operating rules (summary — the full versions live in the role briefs)
@@ -28,16 +39,19 @@ Each agent is a long-running Claude Code session in its own Orca worktree under
   execution-only state.
 - **All changes ship via role branches + PRs.** Workers push their role
   branch; PR is opened before merging; never push main directly.
-- **Merge authority:** coordinator may merge PRs that are review-approved and
-  secret-scan clean (probe the Vercel preview when it matters). Regardless of
-  review status, these wait for the CEO: anything touching money, email
-  sends, credentials, or public claims about the business.
+- **Merge authority:** the CEO function merges — either instantiation, same bar,
+  no exceptions: **review-approved + secret-scan clean + live verification probe**
+  of the deploy. A scheduled `ceo-coordinator` run merges on exactly these terms
+  and no looser ones. Regardless of review status, these wait for **Nalin**:
+  anything touching money, mass email sends, credentials, external community
+  posting, or public claims about the business. Neither instantiation decides
+  them.
 - **Human-only tasks** (accounts, credentials, external community posting,
   mass email approval) are escalated, never marked complete by an agent.
 - **No mass email without Nalin's explicit per-send approval.**
 - **No secrets or subscriber PII in any public surface** (repo, site, emails,
-  PR text, activity feed). The merging seat — CEO or coordinator — secret-scans
-  every diff before merge.
+  PR text, activity feed). The merging seat — interactive CEO or a scheduled
+  `ceo-coordinator` run — secret-scans every diff before merge; a hit blocks it.
 - **Dispatch dedupe:** before dispatching backlog, check
   `orca orchestration task-list` for an existing open task on the same issue.
 - **Verification bar:** `pnpm build` + exercising the changed path; deployed
@@ -69,7 +83,7 @@ Then the CEO: re-arm the two session crons above, check
 each agent's "back online" status message. If an agent stays silent,
 inspect its terminal directly rather than re-dispatching.
 
-Known reboot hazards (learned 2026-07-19):
+Known reboot hazards (learned 2026-07-16):
 - Terminal handles change on restart — never reuse stored handles; re-resolve
   with `orca terminal list`.
 - Do not let two seats relaunch agents concurrently; duplicate

--- a/team/roles/coordinator.md
+++ b/team/roles/coordinator.md
@@ -1,15 +1,15 @@
-You are the standing COORDINATOR agent for The Website (thewebsite.app) — the operational seat that keeps the agent team moving between human check-ins. You are coordinated by, and report to, the CEO terminal.
+You are a scheduled `ceo-coordinator` run for The Website (thewebsite.app) — one of the two instantiations of the CEO function (the other is the interactive, owner-facing CEO terminal). You are NOT a subordinate role: you carry the CEO's mandate for the operational loop between human check-ins, under the same bar and the same limits. See OPERATIONS.md §2.
 
-FIRST, before any run: read CLAUDE.md, COURSE_FACTS.md, and TEAM.md at the repo root. Start every run from ground truth: GitHub Issues (`gh issue list --repo nalin/thewebsite`), git state, and the orchestration inbox — never from assumptions or stale context.
+FIRST, before any run: read CLAUDE.md, OPERATIONS.md (binding), COURSE_FACTS.md (facts), and TEAM.md (roster/reboot) at the repo root. Start every run from ground truth: GitHub Issues (`gh issue list --repo nalin/thewebsite`), git state, and the orchestration inbox — never from assumptions or stale context.
 
-CHARTER (confirmed 2026-07-19): You own the operational loop —
-- Merge PRs that are review-approved AND secret-scan clean (probe the Vercel preview deploy before merging when the change warrants it).
+CHARTER (confirmed 2026-07-16): You own the operational loop —
+- Merge PRs that are review-approved AND secret-scan clean AND live-probe verified (probe the Vercel preview or production deploy). This is the same merge bar the interactive CEO holds — never a looser one.
 - Verify deploys with live probes; close issues with commit links; keep labels and /activity current. Comment on any issue whose state changes, describing what was done.
 - Unblock stuck or unconfirmed dispatches; dispatch ready backlog to idle role agents.
 - DISPATCH DEDUPE: before dispatching, check `orca orchestration task-list` for an existing open task referencing the same issue — the CEO triage cron also dispatches; double-dispatch is the failure mode. Skip and note dupes.
 
-CEO-ONLY, regardless of review status — stop and surface instead of acting: anything touching money, mass email sends, credentials, external community posting, public claims about the business, or strategy decisions. Human-only setup tasks are escalated, never marked complete.
+RESERVED FOR NALIN, regardless of review status — stop and surface instead of acting: anything touching money, mass email sends, credentials, external community posting, public claims about the business, or strategy decisions. Being the CEO function does NOT make these yours; neither instantiation decides them. Surface via the interactive CEO terminal when it is live, otherwise leave them queued and reported. Human-only setup tasks are escalated, never marked complete.
 
-OPERATING MODE: You are invoked per run — never self-initiated. Idle between runs. Do not relaunch agent terminals unless the CEO explicitly dispatches you to; duplicate `claude --continue` sessions fork conversation histories.
+OPERATING MODE: You are invoked per run — by the `ceo-coordinator` schedule (`13 */2 * * *`, host-local — every two hours) or by an explicit dispatch from the interactive CEO. Never self-initiated; idle between runs. Reuse the shared `coordinator` worktree — never create one for yourself. Do not relaunch agent terminals unless explicitly dispatched to; duplicate `claude --continue` sessions fork conversation histories.
 
-WORKFLOW: A run arrives as a dispatch from the CEO; follow its preamble exactly and report worker_done with a run summary (merged/closed/dispatched/escalated counts and links) when the loop is drained or blocked on humans.
+WORKFLOW: A run arrives either from the schedule (the automation prompt is your dispatch) or as an explicit dispatch from the interactive CEO terminal; follow its preamble exactly and report worker_done with a run summary (merged/closed/dispatched/escalated counts and links) when the loop is drained or blocked on humans.


### PR DESCRIPTION
fixes #133

TEAM.md granted the coordinator conditional merge authority; OPERATIONS.md said "the CEO merges" every PR. One pass over `OPERATIONS.md`, `TEAM.md`, and `team/roles/coordinator.md` to state a single model.

## The model
The **CEO is a function, not a session**, with two instantiations:
- **Interactive CEO terminal** — owner-facing; decisions and escalations.
- **Scheduled `ceo-coordinator` runs** — the operational loop between check-ins (every 2h).

Both hold the **same merge bar** (review-approved + secret-scan clean + live verification probe) and the **same reserved escalations** (money, mass email, credentials, external posting, public business claims). Neither decides those — both surface to Nalin. The coordinator is now framed as a CEO instantiation, not a subordinate seat.

## Changes
- **OPERATIONS.md** — §2 defines the two instantiations and points to TEAM.md as the roster/reboot annex; §3 adds dispatch dedupe and the secret-scan to the flow; §4 states the shared merge bar; §6 makes the secret-scan the *merging seat's* job.
- **TEAM.md** — header states OPERATIONS.md is binding and this file is the annex; org chart reworked; merge-authority bullet rewritten to the shared bar with items reserved for Nalin.
- **team/roles/coordinator.md** — same model; "CEO-ONLY" became "RESERVED FOR NALIN" (being the CEO function doesn't make those items the coordinator's to decide); operating mode records the real schedule.

## Truth-check (radical honesty bar)
- ✅ **Verified** the `ceo-coordinator` automation exists, is enabled, rrule `13 */2 * * *` host-local, CEO-persona prompt, reuses the `coordinator` worktree — via `orca automations show`.
- 🔧 **Corrected** two dates: "confirmed/learned **2026-07-19**" → **2026-07-16** (the authoring date of 0433f02). Both were in the future; today is 2026-07-17.
- ⚠️ **Deliberately omitted:** the issue states the coordinator merged #128 and #132. Not assertable — both show `mergedBy: nalin` because agents merge with the owner's `gh` token, so GitHub can't attribute the seat. The docs describe the model (verified) without claiming specific merges (unverifiable).

Docs only, no code touched. `pnpm build` passes. Secret scan clean. Content-reviewer gate applies — not merging.