### PR TITLE
restart-team.sh: launch/resume workers with permission bypass (fixes #137)

### DIFF
--- a/scripts/restart-team.sh
+++ b/scripts/restart-team.sh
@@ -70,27 +70,61 @@ for role in "${ROLES[@]}"; do
       FAILED+=("$role")
       continue
     fi
+    KIND="fresh"
     # #137: the fresh agent must ALSO run with --dangerously-skip-permissions or
     # it re-arms the silent #136 stall on its first novel command. `orca worktree
     # create --agent claude` launches claude WITHOUT the bypass and offers no way
     # to forward the flag, so create the checkout without an agent and start
     # claude ourselves race-free via `orca terminal create --command` (the same
     # mechanism the resume path below uses — --command runs on terminal startup,
-    # so there is no shell-not-ready race a `terminal send` would risk). Role
-    # context is seeded by the re-orientation send further down, which directs
-    # the agent to read team/roles/$role.md — the brief the old --prompt injected.
-    CREATE_MSG=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --base-branch "$BASE_BRANCH" --json | node -e "
-let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.ok===false?'FAIL:'+(j.error?.message||'unknown'):'OK')}catch(e){console.log('OK')}})")
-    if [ "${CREATE_MSG#FAIL:}" != "$CREATE_MSG" ]; then
-      echo "[$role] ERROR: worktree create failed — ${CREATE_MSG#FAIL:} (inspect: orca worktree list)"
+    # so there is no shell-not-ready race a `terminal send` would risk). Fresh
+    # role context is seeded by the fresh-agent branch of the re-orientation send
+    # below, which directs the agent to read team/roles/$role.md first.
+    #
+    # Parse the create response to EITHER the new worktree id or a FAIL: reason.
+    # Fail closed: a false/missing ok, a missing id, or unparseable output ALL
+    # yield FAIL — a parse failure must never read as "assume it worked" (the
+    # inverse of the #132 parse-mistaken-for-a-state bug).
+    CREATE_RES=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --base-branch "$BASE_BRANCH" --json | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+try{
+  const j=JSON.parse(d);
+  if(j.ok!==true){console.log('FAIL:'+(j.error?.message||'create returned ok!=true'));return;}
+  const id=j.result?.worktree?.id;
+  console.log(id?('ID:'+id):'NO_ID');
+}catch(e){console.log('FAIL:unparseable-output')}});")
+    if [ "${CREATE_RES#FAIL:}" != "$CREATE_RES" ]; then
+      echo "[$role] ERROR: worktree create failed — ${CREATE_RES#FAIL:} (inspect: orca worktree list)"
       FAILED+=("$role")
       continue
     fi
-    # Resolve the just-created worktree by name — unique among active worktrees
-    # because we only reach this branch when no active worktree matched the role.
-    HANDLE=$(orca terminal create --worktree "name:$role" --title "$role-agent" --command "claude --dangerously-skip-permissions" --json | node -e "
+    # Resolve the new worktree's id. Prefer the create response's id; if the
+    # runtime didn't return one, re-resolve via the SAME projectId-filtered list
+    # query used for WT_MAP. Never a bare `name:` selector — orca resolves
+    # display names GLOBALLY (no repo scoping on `terminal create`), so a
+    # same-named worktree in another project could match and we would launch a
+    # permission-bypassed claude in the wrong repo.
+    WT_NEW="${CREATE_RES#ID:}"
+    if [ "$WT_NEW" = "NO_ID" ]; then
+      WT_NEW=$(orca worktree list --json | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+try{
+  const ws=JSON.parse(d).result?.worktrees;
+  if(!Array.isArray(ws)){console.log('');return;}
+  for(const w of ws){
+    if(!w.isArchived&&(w.projectId||'').includes('thewebsite')&&w.displayName===process.argv[1]){console.log(w.id);break;}
+  }
+}catch(e){console.log('')}});" "$role")
+    fi
+    if [ -z "$WT_NEW" ]; then
+      echo "[$role] ERROR: created worktree but could not determine its id — inspect: orca worktree list"
+      FAILED+=("$role")
+      continue
+    fi
+    HANDLE=$(orca terminal create --worktree "id:$WT_NEW" --title "$role-agent" --command "claude --dangerously-skip-permissions" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
   else
+    KIND="resume"
     echo "[$role] worktree exists — resuming session with claude --dangerously-skip-permissions --continue"
     HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --dangerously-skip-permissions --continue" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
@@ -101,27 +135,42 @@ let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d
     FAILED+=("$role")
     continue
   fi
-  STARTED+=("$role:$HANDLE")
+  STARTED+=("$role:$HANDLE:$KIND")
   echo "[$role] terminal: $HANDLE"
 done
 
 if [ ${#STARTED[@]} -gt 0 ]; then
   echo "Waiting for TUIs, then sending re-orientation..."
   for entry in ${STARTED[@]+"${STARTED[@]}"}; do
-    role="${entry%%:*}"; handle="${entry##*:}"
+    role="${entry%%:*}"; kind="${entry##*:}"; rest="${entry#*:}"; handle="${rest%:*}"
     orca terminal wait --terminal "$handle" --for tui-idle --timeout-ms 90000 --json >/dev/null
-    if [ -n "$CEO_HANDLE" ]; then
-      CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role back online' --body '<one line: role + any interrupted work>' --json — then idle."
+    # A fresh agent has no prior session and no prior tasks. Resume-wording
+    # ("your session was resumed", "no worker_done for old task IDs", "report
+    # interrupted work") would prime a zero-context agent to confabulate status
+    # — this team's #1 documented failure — so fresh agents get a NEW-agent brief
+    # that tells them to read their role files first and states they have no work.
+    if [ "$kind" = "fresh" ]; then
+      MSG="You are a NEW $role agent in a fresh worktree. FIRST read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md, then confirm and idle. You have no prior tasks."
+      if [ -n "$CEO_HANDLE" ]; then
+        CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role online (fresh)' --body '<one line: role, fresh worktree, no prior work>' --json — then idle."
+      else
+        CONFIRM=" Then idle and await dispatch."
+      fi
     else
-      CONFIRM=" Then idle and await dispatch."
+      MSG="CEO: system restarted; your session was resumed. Terminal handles changed — any pre-restart dispatch preamble is STALE; do NOT send worker_done for old task IDs. You are the $role agent; if context feels thin, re-read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md."
+      if [ -n "$CEO_HANDLE" ]; then
+        CONFIRM=" Confirm by running exactly: orca orchestration send --to $CEO_HANDLE --type status --subject '$role back online' --body '<one line: role + any interrupted work>' --json — then idle."
+      else
+        CONFIRM=" Then idle and await dispatch."
+      fi
     fi
-    orca terminal send --terminal "$handle" --text "CEO: system restarted; your session was resumed. Terminal handles changed — any pre-restart dispatch preamble is STALE; do NOT send worker_done for old task IDs. You are the $role agent; if context feels thin, re-read team/roles/$role.md, CLAUDE.md, COURSE_FACTS.md, TEAM.md.$CONFIRM" --enter --json >/dev/null
+    orca terminal send --terminal "$handle" --text "$MSG$CONFIRM" --enter --json >/dev/null
   done
 
   # Text sent during TUI startup can sit unsubmitted in the input box; nudge.
   sleep 20
   for entry in ${STARTED[@]+"${STARTED[@]}"}; do
-    handle="${entry##*:}"
+    rest="${entry#*:}"; handle="${rest%:*}"
     orca terminal send --terminal "$handle" --text "" --enter --json >/dev/null
   done
 fi

--- a/scripts/restart-team.sh
+++ b/scripts/restart-team.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # restart-team.sh — reboot The Website's standing agent team after a machine
 # or Orca restart. Idempotent: creates missing worktrees (seeded from
-# team/roles/<role>.md), resumes existing ones with `claude --continue`.
+# team/roles/<role>.md), resumes existing ones with
+# `claude --dangerously-skip-permissions --continue`. The bypass is REQUIRED on
+# every worker launch (resume AND fresh): worker worktrees carry no .claude
+# permission allowlist, so a plain `claude` blocks on an invisible permission
+# prompt at its first novel command and stalls silently mid-turn (#136,
+# root-caused and fixed here per #137).
 #
 # Usage: scripts/restart-team.sh [CEO_TERMINAL_HANDLE]
 #   With a CEO handle, each agent is asked to confirm via an orchestration
@@ -56,7 +61,7 @@ for role in "${ROLES[@]}"; do
   WT_ID=$(echo "$WT_MAP" | awk -F'\t' -v r="$role" '$1==r{print $2; exit}')
 
   if [ -z "$WT_ID" ]; then
-    echo "[$role] worktree missing — creating fresh agent seeded from team/roles/$role.md (base: $BASE_BRANCH)"
+    echo "[$role] worktree missing — creating fresh worktree (base: $BASE_BRANCH), launching claude with permission bypass"
     # Fail closed on a base ref that doesn't resolve: creating role worktrees
     # from the wrong (or a silently-defaulted) base is the failure #134 is about.
     # Checked lazily so a resume-only restart is never blocked by it.
@@ -65,12 +70,29 @@ for role in "${ROLES[@]}"; do
       FAILED+=("$role")
       continue
     fi
-    BRIEF=$(cat "$REPO_ROOT/team/roles/$role.md")
-    HANDLE=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --base-branch "$BASE_BRANCH" --agent claude --prompt "$BRIEF" --json | node -e "
-let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.startupTerminal?.handle||'')}catch(e){console.log('')}})")
+    # #137: the fresh agent must ALSO run with --dangerously-skip-permissions or
+    # it re-arms the silent #136 stall on its first novel command. `orca worktree
+    # create --agent claude` launches claude WITHOUT the bypass and offers no way
+    # to forward the flag, so create the checkout without an agent and start
+    # claude ourselves race-free via `orca terminal create --command` (the same
+    # mechanism the resume path below uses — --command runs on terminal startup,
+    # so there is no shell-not-ready race a `terminal send` would risk). Role
+    # context is seeded by the re-orientation send further down, which directs
+    # the agent to read team/roles/$role.md — the brief the old --prompt injected.
+    CREATE_MSG=$(orca worktree create --repo "path:$REPO_ROOT" --name "$role" --no-parent --base-branch "$BASE_BRANCH" --json | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.ok===false?'FAIL:'+(j.error?.message||'unknown'):'OK')}catch(e){console.log('OK')}})")
+    if [ "${CREATE_MSG#FAIL:}" != "$CREATE_MSG" ]; then
+      echo "[$role] ERROR: worktree create failed — ${CREATE_MSG#FAIL:} (inspect: orca worktree list)"
+      FAILED+=("$role")
+      continue
+    fi
+    # Resolve the just-created worktree by name — unique among active worktrees
+    # because we only reach this branch when no active worktree matched the role.
+    HANDLE=$(orca terminal create --worktree "name:$role" --title "$role-agent" --command "claude --dangerously-skip-permissions" --json | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
   else
-    echo "[$role] worktree exists — resuming session with claude --continue"
-    HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --continue" --json | node -e "
+    echo "[$role] worktree exists — resuming session with claude --dangerously-skip-permissions --continue"
+    HANDLE=$(orca terminal create --worktree "id:$WT_ID" --title "$role-agent" --command "claude --dangerously-skip-permissions --continue" --json | node -e "
 let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);console.log(j.result?.terminal?.handle||j.result?.handle||'')}catch(e){console.log('')}})")
   fi
 


### PR DESCRIPTION
Root cause fix for #136 (silent mid-turn worker stall), per #137.

fixes #137

## The bug (from #136 / #137)

Worker worktrees carry no `.claude` permission allowlist. `restart-team.sh` resumed/launched workers with a **plain `claude`**, so the first novel Bash command in a resumed turn — in practice the first `orca ...` call — blocked on an interactive permission dialog. That dialog renders on the TUI alternate screen, which `orca terminal read` can't see, so the worker looked hung: `tool_use` written, no `tool_result`, no child process, one idle API connection. Each Enter approved exactly one tool call (the "nudges buy one round-trip" signature). The 2026-07-16 20:02 restart re-armed this for the entire fleet.

## Changes (script only, +29/−7)

**Resume path** — the common case (worktrees already exist):
`claude --continue` → `claude --dangerously-skip-permissions --continue`. One-flag change.

**Fresh path** (new-worktree cold start): `orca worktree create --agent claude` launches claude **without** the bypass, and the CLI offers no way to forward flags through `--agent` (verified against `orca worktree create --help` — only `--agent <id>` / `--prompt <text>`, no agent-args or `--command`). So:
- Create the checkout **without** an agent, then start claude ourselves via `orca terminal create --command "claude --dangerously-skip-permissions"` — the *same* race-free mechanism the resume path uses (`--command` runs on terminal startup, so no shell-not-ready race that a `terminal send` would risk; `orca terminal wait` only supports `exit|tui-idle`, not a shell-ready state).
- The new worktree is resolved with a **`name:<role>`** selector (verified: `name:engineer` / `name:code-reviewer` resolve, a bogus name returns `selector_not_found`). Unique among active worktrees because we only reach this branch when no active worktree matched the role — avoids depending on the create payload's worktree-id key.
- **Seeding change:** the old fresh path injected the role brief via `--agent claude --prompt "$(cat team/roles/<role>.md)"`. Dropping `--agent` drops that injection (it's coupled to `--agent`). Role context is now seeded by the **existing re-orientation send** further down, which already directs the agent to "re-read team/roles/<role>.md" — the same file the brief came from. Flagging this as a deliberate, minor behavior change; if you'd prefer the brief pushed explicitly to fresh agents, that's an easy follow-up.
- Added a **fail-closed** check on `orca worktree create` (reports on explicit `ok:false` instead of silently proceeding), matching the #132/#138 fail-closed bar. Malformed output still fails closed downstream via the existing empty-handle guard.

Doc comment (line 4) updated to state the bypass is required and why.

## Why `--dangerously-skip-permissions`

It's what #137 specifies and what the validated recovery playbook uses (`claude --dangerously-skip-permissions --resume <id>`). No env-var alternative exists — I grepped the claude binary; there is no `CLAUDE_CODE_*` permission/bypass variable, so the CLI flag is the only mechanism.

## Verification

- `bash -n` clean under default bash **and `/bin/bash` 3.2.57** (the version #132's guards target).
- **shellcheck v0.11.0: clean, exit 0** (pulled via `pnpm dlx`).
- Create-failure detection tested behaviorally: `ok:false` → FAILED branch with the error message; `ok:true` → proceeds; malformed → proceeds (then fails closed at the empty-handle guard).
- `name:<role>` selector resolution tested against live worktrees (resolves real roles, `selector_not_found` on bogus).
- `pnpm build` passes — `scripts/` is not in the build graph, no app impact.
- **Did not run an actual team restart** (would spawn duplicate seeded agents / disrupt the live fleet, the exact hazard TEAM.md warns about). The fresh-path cold-start (worktree-create-without-agent + `name:` launch) is therefore verified by component, not end-to-end; worth a smoke test on the next real cold start.

## Conflict with #138 (eng/restart-team-base-134)

Both PRs edit the fresh-path `orca worktree create` block. #138 adds a base-ref guard + `--base-branch "$BASE_BRANCH"` to that call; this PR replaces the call's `--agent claude --prompt` with the bare-create + `name:` launch. **Whichever merges second will need a small rebase on that one hunk** — reconciliation is mechanical: keep #138's base-ref guard and `--base-branch "$BASE_BRANCH"` on the (now agent-less) `orca worktree create`, and keep this PR's `CREATE_MSG` check + `orca terminal create --command "claude --dangerously-skip-permissions"`. The resume-path and doc-comment hunks don't overlap #138.

Do not merge — code-reviewer gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
