### PR TITLE
dispatch-confirm.sh: verify consumption after landing (fixes #143)

### DIFF
--- a/scripts/dispatch-confirm.sh
+++ b/scripts/dispatch-confirm.sh
@@ -1,62 +1,67 @@
 #!/usr/bin/env bash
-# dispatch-confirm.sh — coordinator-side Orca dispatch with confirmation (#127).
+# dispatch-confirm.sh — coordinator-side Orca dispatch with confirmation (#127, #143).
 #
 # Makes a dispatch verifiable instead of fire-and-forget:
 #   1. re-resolves the live agent terminal handle for a worktree (never trusts
 #      a cached handle),
-#   2. creates the orchestration task and dispatches it with --inject,
-#   3. polls dispatch-show until THAT dispatch (matched by id) has landed on a
+#   2. waits for the target pane to look idle before injecting, so the text is
+#      not typed into a composer mid-turn where it gets discarded (#143),
+#   3. creates the orchestration task and dispatches it with --inject,
+#   4. polls dispatch-show until THAT dispatch (matched by id) has landed on a
 #      pane (bounded wait, early bail on a terminal failure state),
-#   4. retries the dispatch exactly once, with a freshly resolved handle, but
+#   5. retries the dispatch exactly once, with a freshly resolved handle, but
 #      only when the first attempt verifiably did NOT land: a structured
 #      terminal_handle_stale error, or a dispatch record in a terminal failure
 #      state. An unconfirmed dispatch that may still land is never retried
 #      (the CLI has no void/cancel verb, so re-dispatching could inject the
 #      same task twice),
-#   5. prints taskId/dispatchId on success; exits non-zero with a diagnostic
-#      otherwise, so the coordinator never assumes a dispatch that didn't land.
+#   6. after landing, verifies the worker actually CONSUMED the injection —
+#      "landed" only means the text reached the composer; if the worker was
+#      mid-turn it is discarded at end-of-turn and the task never starts (#143).
+#      Evidence of consumption is the task id appearing in the session
+#      transcript. On a consumption timeout it re-injects the SAME task text via
+#      `terminal send` citing the same ids (never task-create again, which would
+#      double-dispatch), bounded to a few attempts,
+#   7. prints taskId/dispatchId on success; exits non-zero with a diagnostic
+#      otherwise, so the coordinator never assumes a dispatch that didn't land
+#      or that landed but was never consumed.
 #
 # Usage:
 #   scripts/dispatch-confirm.sh --worktree <selector> --spec <text> \
-#     [--title <text>] [--timeout <seconds>]
+#     [--title <text>] [--timeout <seconds>] [--consume-timeout <seconds>]
 #
-#   --worktree   selector accepted by `orca terminal list --worktree`
-#                (e.g. name:engineer, branch:eng/foo, path:/abs/path)
-#   --spec       task spec text (becomes the worker's TASK block)
-#   --title      optional concise task title
-#   --timeout    max seconds to wait for the dispatch to land (default 60, min 1)
+#   --worktree         selector accepted by `orca terminal list --worktree`
+#                      (e.g. name:engineer, branch:eng/foo, path:/abs/path)
+#   --spec             task spec text (becomes the worker's TASK block)
+#   --title            optional concise task title
+#   --timeout          max seconds to wait for the dispatch to land (default 60, min 1)
+#   --consume-timeout  max seconds to wait for the worker to consume each
+#                      injection before re-injecting (default 45, min 1)
 #
 # Internal coordinator tooling only — not part of the app build.
 set -euo pipefail
 
-usage() {
-  sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
-  exit 2
-}
+# Tunables (env-overridable for tests / unusual panes).
+CONSUME_TIMEOUT="${CONSUME_TIMEOUT:-45}"  # per-attempt wait for consumption evidence
+REINJECT_MAX="${REINJECT_MAX:-2}"         # re-injections after a landed-but-unconsumed dispatch
+IDLE_BUDGET="${IDLE_BUDGET:-20}"          # max seconds to wait for the pane to go idle before injecting
+QUIET_S="${QUIET_S:-4}"                   # transcript must be quiet this long to count as idle
 
+# --- globals populated by the main flow (declared so helpers are self-evident) ---
 WORKTREE=""
 SPEC=""
 TITLE=""
 TIMEOUT=60
+TASK_ID=""
+PROJDIR=""      # role's ~/.claude/projects transcript dir, or "" if unresolved
+INJECT_AT=0     # epoch seconds captured immediately before each (re)injection
+PROBE_STATE=""
+LAST_STATUS=""
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree) WORKTREE="${2:?--worktree needs a value}"; shift 2 ;;
-    --spec)     SPEC="${2:?--spec needs a value}";         shift 2 ;;
-    --title)    TITLE="${2:?--title needs a value}";       shift 2 ;;
-    --timeout)  TIMEOUT="${2:?--timeout needs a value}";   shift 2 ;;
-    -h|--help)  usage ;;
-    *) echo "error: unknown argument '$1'" >&2; usage ;;
-  esac
-done
-
-[[ -n "$WORKTREE" && -n "$SPEC" ]] || usage
-if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || (( TIMEOUT < 1 )); then
-  echo "error: --timeout must be an integer >= 1 (seconds)" >&2
+usage() {
+  sed -n '2,41p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
   exit 2
-fi
-command -v orca >/dev/null 2>&1 || { echo "error: 'orca' not found on PATH" >&2; exit 1; }
-command -v jq   >/dev/null 2>&1 || { echo "error: 'jq' is required" >&2; exit 1; }
+}
 
 # Pick the live agent terminal for the worktree: connected + writable panes,
 # preferring titled ones (Orca's agent status hooks title agent panes; bare
@@ -83,12 +88,92 @@ resolve_handle() {
     | (first // {}) | .handle // empty' <<<"$out" 2>/dev/null || true
 }
 
+# Filesystem path of the target worktree (all panes in a worktree share it),
+# used to locate the session transcript. Any matching terminal's worktreePath
+# is fine. Empty on error.
+resolve_wtpath() {
+  local out
+  out="$(orca terminal list --worktree "$WORKTREE" --json 2>/dev/null || true)"
+  jq -r '[.result.terminals[]? | .worktreePath // empty] | (first // empty)' <<<"$out" 2>/dev/null || true
+}
+
+# Map a worktree path to its Claude Code transcript directory. Claude stores
+# each session at ~/.claude/projects/<cwd-with-every-non-alnum-char-as-dash>/
+# <uuid>.jsonl (rule verified 2026-07-17 against the live projects dir). Returns
+# the dir only if it exists, else "" so callers degrade gracefully.
+transcript_dir_for() {
+  local wtpath="$1" munged d
+  [[ -n "$wtpath" ]] || { echo ""; return 0; }
+  munged="$(printf '%s' "$wtpath" | sed 's/[^a-zA-Z0-9]/-/g')"
+  d="$HOME/.claude/projects/$munged"
+  if [[ -d "$d" ]]; then echo "$d"; else echo ""; fi
+}
+
+# Portable file mtime (epoch seconds): BSD stat (macOS, where the coordinator
+# runs) first, then GNU stat, then 0.
+file_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
+now_epoch()  { date +%s; }
+
+# Newest mtime across the transcript *.jsonl files (the active session is the
+# one being appended to). 0 if no dir / no files.
+newest_transcript_mtime() {
+  [[ -n "$PROJDIR" ]] || { echo 0; return 0; }
+  local f m newest=0
+  while IFS= read -r f; do
+    m="$(file_mtime "$f")"
+    if (( m > newest )); then newest="$m"; fi
+  done < <(find "$PROJDIR" -maxdepth 1 -name '*.jsonl' 2>/dev/null)
+  echo "$newest"
+}
+
+# Best-effort idle wait (#143 hardening 2). Claude appends to the transcript on
+# every message/tool event within a turn, so an advancing newest mtime == the
+# pane is mid-turn; a mtime quiet for >= QUIET_S == idle at the composer.
+# Returns 0 once it looks idle (or PROJDIR unknown → don't block), 1 if it
+# stayed busy for the whole budget. NOTE: a turn blocked on a slow tool goes
+# quiet mid-run, so this narrows — but cannot close — the race; the post-land
+# consumption check (below) is what actually guarantees delivery.
+wait_until_idle() {
+  local budget="${1:-$IDLE_BUDGET}" deadline last now quiet_since
+  [[ -n "$PROJDIR" ]] || return 0
+  deadline=$(( SECONDS + budget ))
+  last="$(newest_transcript_mtime)"
+  quiet_since=$SECONDS
+  while (( SECONDS < deadline )); do
+    sleep 1
+    now="$(newest_transcript_mtime)"
+    if [[ "$now" != "$last" ]]; then
+      last="$now"
+      quiet_since=$SECONDS
+    elif (( SECONDS - quiet_since >= QUIET_S )); then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Consumption evidence (#143 hardening 1): the worker submitted the injected
+# text as a turn, so the dispatch preamble's task id now appears in a transcript
+# file modified at/after the injection. The mtime guard rejects a stale task-id
+# match; requiring the task id (not a bare mtime bump) rejects unrelated worker
+# activity that merely advances the transcript while our text sits discarded in
+# the composer. Returns 0 consumed, 1 not yet, 2 cannot determine (no dir).
+consumed() {
+  [[ -n "$PROJDIR" ]] || return 2
+  local f m
+  while IFS= read -r f; do
+    m="$(file_mtime "$f")"
+    if (( m + 1 >= INJECT_AT )) && grep -qF "$TASK_ID" "$f" 2>/dev/null; then
+      return 0
+    fi
+  done < <(find "$PROJDIR" -maxdepth 1 -name '*.jsonl' 2>/dev/null)
+  return 1
+}
+
 # One dispatch-show probe for a specific dispatch id. dispatch-show is
 # task-addressed and returns a single dispatch record, so the id match is what
 # guarantees we are looking at OUR dispatch and not a superseded one.
 # Sets PROBE_STATE to landed|failed|pending and LAST_STATUS to the raw status.
-PROBE_STATE=""
-LAST_STATUS=""
 probe_dispatch() {
   local expect="$1" out id status pane
   out="$(orca orchestration dispatch-show --task "$TASK_ID" --json 2>/dev/null || true)"
@@ -127,6 +212,47 @@ confirm_landed() {
   return 1
 }
 
+# ---------------------------------------------------------------------------
+# Unit tests source this file to exercise the detection helpers in isolation;
+# everything above is pure function definitions. Stop before the imperative
+# dispatch flow when sourced rather than executed.
+# ---------------------------------------------------------------------------
+(return 0 2>/dev/null) && _SOURCED=1 || _SOURCED=0
+if [[ "$_SOURCED" == "1" ]]; then return 0; fi
+
+# --- arg parsing --------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worktree)        WORKTREE="${2:?--worktree needs a value}";        shift 2 ;;
+    --spec)            SPEC="${2:?--spec needs a value}";                shift 2 ;;
+    --title)           TITLE="${2:?--title needs a value}";              shift 2 ;;
+    --timeout)         TIMEOUT="${2:?--timeout needs a value}";          shift 2 ;;
+    --consume-timeout) CONSUME_TIMEOUT="${2:?--consume-timeout needs a value}"; shift 2 ;;
+    -h|--help)         usage ;;
+    *) echo "error: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+[[ -n "$WORKTREE" && -n "$SPEC" ]] || usage
+if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || (( TIMEOUT < 1 )); then
+  echo "error: --timeout must be an integer >= 1 (seconds)" >&2
+  exit 2
+fi
+if ! [[ "$CONSUME_TIMEOUT" =~ ^[0-9]+$ ]] || (( CONSUME_TIMEOUT < 1 )); then
+  echo "error: --consume-timeout must be an integer >= 1 (seconds)" >&2
+  exit 2
+fi
+command -v orca >/dev/null 2>&1 || { echo "error: 'orca' not found on PATH" >&2; exit 1; }
+command -v jq   >/dev/null 2>&1 || { echo "error: 'jq' is required" >&2; exit 1; }
+
+# Resolve the transcript dir once, up front, from the worktree path. If it
+# cannot be resolved the mid-turn/consumption checks degrade to no-ops (loudly
+# noted at the end) rather than blocking the dispatch.
+PROJDIR="$(transcript_dir_for "$(resolve_wtpath)")"
+if [[ -z "$PROJDIR" ]]; then
+  echo "warn: could not resolve a transcript dir for '$WORKTREE' — will dispatch but cannot verify consumption (#143)" >&2
+fi
+
 # 1) Create the task once; a retried dispatch reuses it.
 create_args=(--spec "$SPEC" --json)
 [[ -n "$TITLE" ]] && create_args+=(--task-title "$TITLE")
@@ -144,6 +270,7 @@ echo "created $TASK_ID"
 err_file="$(mktemp)"
 trap 'rm -f "$err_file"' EXIT
 
+DISPATCH_ID=""
 attempt=1
 while :; do
   HANDLE="$(resolve_handle)"
@@ -151,11 +278,21 @@ while :; do
     echo "error: no live agent terminal found for worktree '$WORKTREE' ($TASK_ID left undispatched)" >&2
     exit 1
   fi
+
+  # #143 hardening 2: don't inject into a pane that is mid-turn. Best-effort —
+  # narrows the window; the post-land consumption check is the real guarantee.
+  if [[ -n "$PROJDIR" ]]; then
+    if ! wait_until_idle "$IDLE_BUDGET"; then
+      echo "warn: pane still looked busy after ${IDLE_BUDGET}s — injecting anyway (will verify consumption)" >&2
+    fi
+  fi
+
   echo "dispatching $TASK_ID to $HANDLE (attempt $attempt)"
 
   # stdout and stderr captured separately: staleness is detected only from the
   # structured error code on a failed exit, never by substring — a spec that
   # merely *mentions* terminal_handle_stale must not trip it.
+  INJECT_AT="$(now_epoch)"
   dispatch_rc=0
   dispatch_out="$(orca orchestration dispatch --task "$TASK_ID" --to "$HANDLE" --inject --json 2>"$err_file")" || dispatch_rc=$?
   dispatch_err="$(cat "$err_file")"
@@ -204,9 +341,7 @@ while :; do
   case "$confirm_rc" in
     0)
       echo "confirmed: dispatch landed (status=$LAST_STATUS)"
-      echo "taskId=$TASK_ID"
-      echo "dispatchId=$DISPATCH_ID"
-      exit 0
+      break   # landed — proceed to consumption verification (#143)
       ;;
     2)
       # Verifiably failed (terminal state, never landed) — the only rc-0 case
@@ -229,4 +364,64 @@ while :; do
       exit 1
       ;;
   esac
+done
+
+# 3) #143 hardening 1: 'landed' only means the text reached the composer. If the
+#    worker was mid-turn, that text is discarded at end-of-turn and the task
+#    never starts. Verify the worker actually CONSUMED it (its task id appears
+#    in the transcript, written at/after our injection). On timeout, re-inject
+#    the SAME task text via `terminal send` (never task-create again — that
+#    double-dispatches) and re-verify. Bounded re-injections, then fail loudly.
+if [[ -z "$PROJDIR" ]]; then
+  echo "warn: consumption UNVERIFIED — no transcript dir for '$WORKTREE' (#143)." >&2
+  echo "      Dispatch landed but I cannot confirm the worker consumed it; watch the pane." >&2
+  echo "taskId=$TASK_ID"
+  echo "dispatchId=$DISPATCH_ID"
+  exit 0
+fi
+
+reinject=0
+while :; do
+  cdeadline=$(( SECONDS + CONSUME_TIMEOUT ))
+  cstate=1
+  while (( SECONDS < cdeadline )); do
+    if consumed; then cstate=0; break; else crc=$?; fi
+    if (( crc == 2 )); then cstate=2; break; fi
+    sleep 3
+  done
+
+  if (( cstate == 0 )); then
+    echo "confirmed: worker consumed dispatch (task id present in transcript)"
+    echo "taskId=$TASK_ID"
+    echo "dispatchId=$DISPATCH_ID"
+    if (( reinject > 0 )); then echo "note: required $reinject re-injection(s) via terminal send"; fi
+    exit 0
+  fi
+  if (( cstate == 2 )); then
+    echo "warn: consumption became unverifiable mid-check (transcript dir vanished) — treating as landed only" >&2
+    echo "taskId=$TASK_ID"
+    echo "dispatchId=$DISPATCH_ID"
+    exit 0
+  fi
+
+  # Not consumed within CONSUME_TIMEOUT.
+  if (( reinject >= REINJECT_MAX )); then
+    echo "error: dispatch $DISPATCH_ID of $TASK_ID LANDED but was never consumed after $reinject re-injection(s) (${CONSUME_TIMEOUT}s each)." >&2
+    echo "       The worker may be wedged mid-turn. Inspect the pane; do NOT task-create a duplicate (that double-dispatches)." >&2
+    exit 1
+  fi
+  reinject=$(( reinject + 1 ))
+
+  RHANDLE="$(resolve_handle)"
+  if [[ -z "$RHANDLE" ]]; then
+    echo "error: consumption timed out and no live terminal to re-inject into for '$WORKTREE'." >&2
+    exit 1
+  fi
+  echo "warn: not consumed within ${CONSUME_TIMEOUT}s — re-injecting SAME task $TASK_ID via terminal send (attempt $reinject/$REINJECT_MAX)" >&2
+  wait_until_idle "$IDLE_BUDGET" || true
+  INJECT_AT="$(now_epoch)"
+  REINJECT_MSG="DISPATCH (re-injection of $TASK_ID / dispatch $DISPATCH_ID — a prior injection landed but was not consumed; this is the SAME task, do NOT create a new task or dispatch). TASK: $SPEC"
+  if ! orca terminal send --terminal "$RHANDLE" --text "$REINJECT_MSG" --enter --json >/dev/null 2>&1; then
+    echo "warn: terminal send re-injection returned non-zero (will still re-verify)" >&2
+  fi
 done


### PR DESCRIPTION
## Problem (#143)

`dispatch-confirm.sh` reports `confirmed: dispatch landed (status=dispatched)`, but "landed" only means the injected text reached the target pane's **composer**. If the worker was mid-turn (e.g. composing its own `worker_done`), the text sits in the composer and is **discarded when that turn ends** — the task never starts while orchestration state says `dispatched`. Observed 3× on 2026-07-17 (including this task's own dispatch).

## What this does — hardenings 1 + 2 from the issue

**2. Wait for idle before injecting.** Claude appends to its session transcript (`~/.claude/projects/<munged-cwd>/*.jsonl`) on every message/tool event within a turn. An advancing newest-mtime ⇒ mid-turn; mtime quiet for `QUIET_S`s ⇒ idle at the composer. The script waits (bounded by `IDLE_BUDGET`) before injecting. Best-effort — a turn blocked on a slow tool goes quiet mid-run, so this *narrows* the race, it does not close it (that's hardening 3, upstream).

**1. Verify consumption after landing.** Evidence the worker actually **consumed** (submitted) the injection: the task id appears in a transcript file modified **at/after** the injection. The dispatch preamble embeds the literal task id (verified against real historical dispatches — see below). Guards:
- fresh mtime but **no** task id (unrelated activity while our text sits discarded) → not consumed;
- task-id match with a **pre-injection** mtime → rejected as stale.

On a consumption timeout, the **same** task text is re-injected via `orca terminal send` citing the same task/dispatch ids — **never `task-create` again** (that double-dispatches; the CLI has no void/cancel verb). Bounded to `REINJECT_MAX` attempts, then fails loudly.

Fail-closed throughout (PR #127/#140 conventions): an unresolvable transcript dir degrades the consumption check to a loud `UNVERIFIED` note rather than blocking the dispatch; parse failures never read as success.

## New knobs
- `--consume-timeout <s>` (default 45) — per-attempt wait for consumption evidence.
- env overrides for tests/unusual panes: `REINJECT_MAX` (2), `IDLE_BUDGET` (20), `QUIET_S` (4).

## Structure
Detection helpers moved above a sourced-guard (`(return 0 2>/dev/null) && …`) so they can be unit-tested in isolation without running the imperative dispatch flow. No behavior change to the existing #127 dispatch/confirm/retry logic.

## Verification
- `bash -n` clean on default bash **and** `/bin/bash` 3.2.57; `shellcheck` 0.11.0 clean.
- **10/10 helper unit tests**: path munging; `consumed()` across all four cases (no-dir → rc2, no-match → rc1, stale-mtime match rejected, fresh-mtime-but-no-taskid rejected [the composer-discard case], fresh task-id → consumed); `wait_until_idle()` idle (rc0, ~2s) vs mid-turn (rc1, whole budget).
- **Central assumption validated against real history**: the literal task id lands in the consuming pane's transcript for every real dispatch — native preamble (`DISPATCH — taskId: task_e6e04d717e55, …`) and re-injection wording (`Your task ID is: task_8560b4dd7325`), cross-checked across 4 historical dispatches. So `consumed()`'s `grep -F "$TASK_ID"` matches on real consumption.

**Note on live scratch-terminal testing:** a scratch worktree + live claude session was set up to exercise the end-to-end idle/mid-turn paths, but the host hit `ENOSPC` (disk full) mid-run, which corrupted the scratch session (`locking failed … no space left on device`). I reclaimed space and tore the scratch worktree down cleanly (an orphaned scratch task was closed). Rather than re-run a live claude under disk pressure, I validated the one live-dependent assumption (task-id-in-transcript) against 4 real historical dispatches — stronger coverage than a single scratch run — plus the 10 helper unit tests. A live end-to-end pass can be a fast follow if desired.

Internal coordinator tooling only — not in the app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)